### PR TITLE
Disable unmaintained uploaders

### DIFF
--- a/src/uploaders/imgurloginuploader.cpp
+++ b/src/uploaders/imgurloginuploader.cpp
@@ -1,3 +1,5 @@
+/* TODO Re-enable me!  (See imgurloginuploader.h) */
+#if 0
 #include "imgurloginuploader.h"
 #include "ui_imguranonuploader.h"
 #include "ui_imgurloginuploader.h"
@@ -187,3 +189,4 @@ void ImgurLoginUploader::setAuthorization(NetworkTransaction *tr)
 {
 	tr->setRawHeader("Authorization", QString("Bearer " + accessToken).toAscii());
 }
+#endif // 0

--- a/src/uploaders/imgurloginuploader.h
+++ b/src/uploaders/imgurloginuploader.h
@@ -1,6 +1,16 @@
 #ifndef IMGURLOGINUPLOADER_H
 #define IMGURLOGINUPLOADER_H
 
+/* TODO Re-enable me!
+ *
+ * Imgur uploader for logged in users has been disabled due to removal of WebKit
+ * module from Qt.
+ *
+ * Possible solutions:
+ * - This uploader should use WebEngine (Chromium) instead of WebKit.
+ */
+#if 0
+
 #include "imguranonuploader.h"
 #include <QWidget>
 #include <QWebView>
@@ -42,3 +52,4 @@ protected:
 };
 
 #endif // IMGURLOGINUPLOADER_H
+#endif // 0

--- a/src/uploaders/isanonuploader.cpp
+++ b/src/uploaders/isanonuploader.cpp
@@ -1,3 +1,6 @@
+/* TODO Re-enable me!  (See respective header file) */
+#if 0
+
 #include "isanonuploader.h"
 #include "ui_isanonuploader.h"
 #include "networktransaction.h"
@@ -60,3 +63,5 @@ QString IsAnonUploader::postTransaction(NetworkTransactionMultiPart *tr, QIODevi
 	image->close();
 	return link;
 }
+
+#endif // 0

--- a/src/uploaders/isanonuploader.h
+++ b/src/uploaders/isanonuploader.h
@@ -1,6 +1,15 @@
 #ifndef ISANONYUPLOADER_H
 #define ISANONYUPLOADER_H
 
+/* TODO Fix and re-enable me!
+ *
+ * All ImageShack uploaders are all totally broken, and have been disabled:
+ * - They do not work.
+ * - They do not use current API.
+ * - Amount of required changes is unknown.
+ */
+#if 0
+
 #include "abstractuploader.h"
 
 class NetworkTransactionMultiPart;
@@ -27,4 +36,5 @@ private:
 	Ui::IsAnonUploader *ui;
 };
 
+#endif // 0
 #endif // ISANONYUPLOADER_H

--- a/src/uploaders/iscodeuploader.cpp
+++ b/src/uploaders/iscodeuploader.cpp
@@ -1,3 +1,6 @@
+/* TODO Re-enable me!  (See respective header file) */
+#if 0
+
 #include "iscodeuploader.h"
 #include "ui_iscodeuploader.h"
 #include "networktransactionmultipart.h"
@@ -23,3 +26,5 @@ QString IsCodeUploader::uploadImage(QString filePath, QIODevice *image)
 	tr->addHttpPart("cookie", ui->codeEdit->text().toAscii());
 	return postTransaction(tr, image);
 }
+
+#endif // 0

--- a/src/uploaders/iscodeuploader.h
+++ b/src/uploaders/iscodeuploader.h
@@ -1,6 +1,15 @@
 #ifndef ISCODEUPLOADER_H
 #define ISCODEUPLOADER_H
 
+/* TODO Fix and re-enable me!
+ *
+ * All ImageShack uploaders are all totally broken, and have been disabled:
+ * - They do not work.
+ * - They do not use current API.
+ * - Amount of required changes is unknown.
+ */
+#if 0
+
 #include "isanonuploader.h"
 
 namespace Ui {
@@ -20,4 +29,5 @@ private:
 	Ui::IsCodeUploader *ui;
 };
 
+#endif // 0
 #endif // ISCODEUPLOADER_H

--- a/src/uploaders/isloginuploader.cpp
+++ b/src/uploaders/isloginuploader.cpp
@@ -1,3 +1,6 @@
+/* TODO Re-enable me!  (See respective header file) */
+#if 0
+
 #include "isloginuploader.h"
 #include "ui_isloginuploader.h"
 #include "networktransactionmultipart.h"
@@ -32,3 +35,5 @@ QString IsLoginUploader::uploadImage(QString filePath, QIODevice *image)
 	tr->addHttpPart("a_password", password.toAscii());
 	return postTransaction(tr, image);
 }
+
+#endif // 0

--- a/src/uploaders/isloginuploader.h
+++ b/src/uploaders/isloginuploader.h
@@ -1,6 +1,15 @@
 #ifndef ISLOGINUPLOADER_H
 #define ISLOGINUPLOADER_H
 
+/* TODO Fix and re-enable me!
+ *
+ * All ImageShack uploaders are all totally broken, and have been disabled:
+ * - They do not work.
+ * - They do not use current API.
+ * - Amount of required changes is unknown.
+ */
+#if 0
+
 #include "isanonuploader.h"
 
 namespace Ui {
@@ -20,4 +29,5 @@ private:
 	Ui::IsLoginUploader *ui;
 };
 
+#endif // 0
 #endif // ISLOGINUPLOADER_H

--- a/src/uploaders/uploaderfactory.cpp
+++ b/src/uploaders/uploaderfactory.cpp
@@ -48,7 +48,8 @@ UploaderFactory::UploaderFactory()
 //	TODO Re-enable me!  (See ftpuploader.h)
 //	UPLOADER(FtpUploader, tr("Własne konto FTP"));
 	UPLOADER(ImgurAnonUploader, tr("Imgur anonimowo"));
-	UPLOADER(ImgurLoginUploader, tr("Imgur konto"));
+//	TODO Re-enable me!  (See imgurloginuploader.h)
+//	UPLOADER(ImgurLoginUploader, tr("Imgur konto"));
 }
 
 UploaderFactory::~UploaderFactory()

--- a/src/uploaders/uploaderfactory.cpp
+++ b/src/uploaders/uploaderfactory.cpp
@@ -42,13 +42,13 @@ private:
 
 UploaderFactory::UploaderFactory()
 {
-	UPLOADER(IsAnonUploader, tr("Imageshack anonimowo"));
-	UPLOADER(IsCodeUploader, tr("Imageshack kod rejestracyjny"));
-	UPLOADER(IsLoginUploader, tr("Imageshack login i hasło"));
-//	TODO Re-enable me!  (See ftpuploader.h)
+//	TODO Re-enable uploaders!  (See respective header files)
+
+//	UPLOADER(IsAnonUploader, tr("Imageshack anonimowo"));
+//	UPLOADER(IsCodeUploader, tr("Imageshack kod rejestracyjny"));
+//	UPLOADER(IsLoginUploader, tr("Imageshack login i hasło"));
 //	UPLOADER(FtpUploader, tr("Własne konto FTP"));
 	UPLOADER(ImgurAnonUploader, tr("Imgur anonimowo"));
-//	TODO Re-enable me!  (See imgurloginuploader.h)
 //	UPLOADER(ImgurLoginUploader, tr("Imgur konto"));
 }
 


### PR DESCRIPTION
* Disable all uploaders for ImageShack. These are probably currently broken.
* Disable Imgur uploader for signed in users. It requires to be migrated to WebEngine. Apart from that, it is probably in a quite good condition.