### PR TITLE
Migrate from WebKit to WebEngine

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@
 # top-most EditorConfig file
 root = true
 
-[*.{h,hpp,c,cpp,pri,pro}]
+[*.{h,hpp,c,cpp,pri,pro,js}]
 charset = utf-8
 end_of_line = lf
 indent_style = tab

--- a/fotorelacjonusz.pro
+++ b/fotorelacjonusz.pro
@@ -169,7 +169,11 @@ FORMS += \
 	src/uploaders/ftpuploader.ui
 
 RESOURCES += \
-	resource.qrc
+	resource.qrc \
+	webscripts.qrc
+
+# Prevent JavaScripts from being compiled to C++ sources.
+QTQUICK_COMPILER_SKIPPED_RESOURCES += webscripts.qrc
 
 OTHER_FILES += \
 	res/page.html

--- a/fotorelacjonusz.pro
+++ b/fotorelacjonusz.pro
@@ -49,6 +49,7 @@ SOURCES += \
 	src/messagehandler.cpp \
 	src/exception.cpp \
 	src/application.cpp \
+	src/embeddedjavascript.cpp \
 	src/widgets/threadedvalidator.cpp \
 	src/widgets/selectablewidget.cpp \
 	src/widgets/replydialog.cpp \
@@ -103,6 +104,7 @@ HEADERS += \
 	src/messagehandler.h \
 	src/exception.h \
 	src/application.h \
+	src/embeddedjavascript.h \
 	src/widgets/threadedvalidator.h \
 	src/widgets/selectablewidget.h \
 	src/widgets/replydialog.h \

--- a/fotorelacjonusz.pro
+++ b/fotorelacjonusz.pro
@@ -8,7 +8,7 @@ TEMPLATE = app
 TARGET = fotorelacjonusz
 VERSION = 2.99.0
 
-QT += core gui network webkit webkitwidgets script widgets xml xmlpatterns
+QT += core gui network script webengine webenginewidgets widgets xml xmlpatterns
 
 # Enable C++11 explicitly, which should make proper stdlib available.
 # Required to compile at least on OS X.

--- a/fotorelacjonusz.pro
+++ b/fotorelacjonusz.pro
@@ -8,7 +8,7 @@ TEMPLATE = app
 TARGET = fotorelacjonusz
 VERSION = 2.99.0
 
-QT += core gui network script webengine webenginewidgets widgets xml xmlpatterns
+QT += core gui network script webchannel webengine webenginewidgets widgets xml xmlpatterns
 
 # Enable C++11 explicitly, which should make proper stdlib available.
 # Required to compile at least on OS X.

--- a/src/embeddedjavascript.cpp
+++ b/src/embeddedjavascript.cpp
@@ -1,0 +1,34 @@
+#include "embeddedjavascript.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QWebEngineProfile>
+#include <QWebEngineScriptCollection>
+#include <QtCore/QStringBuilder>
+
+EmbeddedJavascript::EmbeddedJavascript(QString scriptSourcePath)
+{
+	QFile sourceFile(scriptSourcePath);
+	QFileInfo scriptInfo(sourceFile);
+
+	sourceFile.open(QIODevice::ReadOnly);
+	setSourceCode(sourceFile.readAll());
+	setName("Fotorelacjonusz: " % scriptInfo.baseName());
+	setWorldId(worldId);
+}
+
+EmbeddedJavascript::~EmbeddedJavascript()
+{
+}
+
+/**
+ * @brief Reads script source from given path, and uploads it to the browser's
+ * default profile.
+ * @param scriptSourcePath QString resource path to script source
+ */
+void EmbeddedJavascript::insertIntoProfile(QString scriptName)
+{
+	auto profile = QWebEngineProfile::defaultProfile();
+	EmbeddedJavascript script(scriptName);
+	profile->scripts()->insert(script);
+}

--- a/src/embeddedjavascript.h
+++ b/src/embeddedjavascript.h
@@ -1,0 +1,37 @@
+#ifndef EMBEDDEDJAVASCRIPT_H
+#define EMBEDDEDJAVASCRIPT_H
+
+#include <QWebEngineScript>
+
+/**
+ * @brief Easy way to inject client-side scripts to embedded Chromium browser.
+ *
+ * A convenience QWebEngineScript subclass which is responsible for uploading
+ * JavaScript files from Qt resource collections (*.qrc) to the default profile
+ * of embedded browser.
+ *
+ * Example usage:
+ *
+ * @code
+ * EmbeddedJavascript::insertIntoProfile(":/src/web/ssc.js");
+ * @endcode
+ *
+ * @note By project's convention, scripts should be stored in /src/web
+ * directory.
+ */
+class EmbeddedJavascript : public QWebEngineScript
+{
+
+public:
+	explicit EmbeddedJavascript(QString scriptName);
+	EmbeddedJavascript(const EmbeddedJavascript&) = delete;
+	virtual ~EmbeddedJavascript();
+
+	static void insertIntoProfile(QString scriptName);
+
+	/// Browser's world ID in which scripts managed by this class are going
+	/// to be executed.
+	static const auto worldId = QWebEngineScript::ApplicationWorld;
+};
+
+#endif // EMBEDDEDJAVASCRIPT_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,7 @@ int main(int argc, char *argv[])
 
 	a.installTranslator(&translator);
 
+	EmbeddedJavascript::insertIntoProfile(":/qtwebchannel/qwebchannel.js");
 	EmbeddedJavascript::insertIntoProfile(":/src/web/ssc.js");
 
 	MainWindow w;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include "widgets/mainwindow.h"
 #include "messagehandler.h"
+#include "embeddedjavascript.h"
 
 #ifdef Q_OS_UNIX
 
@@ -58,6 +59,8 @@ int main(int argc, char *argv[])
 		qDebug() << "Loading :/fotorelacjonusz_en_US:" << translator.load(":/fotorelacjonusz_en_US");
 
 	a.installTranslator(&translator);
+
+	EmbeddedJavascript::insertIntoProfile(":/src/web/ssc.js");
 
 	MainWindow w;
 	w.setWindowTitle(a.applicationName());

--- a/src/uploaders/imgurloginuploader.ui
+++ b/src/uploaders/imgurloginuploader.ui
@@ -18,7 +18,7 @@
     <enum>QFormLayout::ExpandingFieldsGrow</enum>
    </property>
    <item row="0" column="0" colspan="2">
-    <widget class="QWebView" name="webView">
+    <widget class="QWebEngineView" name="webView">
      <property name="url">
       <url>
        <string>about:blank</string>
@@ -30,9 +30,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QWebView</class>
+   <class>QWebEngineView</class>
    <extends>QWidget</extends>
-   <header>QtWebKit/QWebView</header>
+   <header>QWebEngineView</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/web/ssc.js
+++ b/src/web/ssc.js
@@ -1,0 +1,6 @@
+// ==UserScript==
+// @match *://www.skyscrapercity.com/*
+// @run-at document-end
+// ==/UserScript==
+
+alert("hello")

--- a/src/web/ssc.js
+++ b/src/web/ssc.js
@@ -27,5 +27,87 @@
 
 		replyDialog = channel.objects.replyDialog
 		replyDialog.forumPageLoaded(location.href)
+		detectPageType()
+	}
+
+	////////////////
+
+	/**
+	 * Detects page type by its location, and calls appropriate handler
+	 * with no arguments.
+	 */
+	function detectPageType() {
+		switch(window.location.pathname) {
+			case "/newreply.php": itsANewReplyPage() ; break
+			case "/showthread.php": itsAShowThreadPage() ; break
+		}
+	}
+
+	/**
+	 * This is a handler for newreply.php page.  Being on this page means one of
+	 * two things: that new post can be submitted or that submission of previous
+	 * post has failed (typically due to throttling).
+	 *
+	 * This handler tells these two apart, and notifies replyDialog accordingly.
+	 */
+	function itsANewReplyPage() {
+		if (isThrottled()) {
+			replyDialog.forumReplySubmissionFailed()
+		} else {
+			scrollToForm()
+			waitForReplyBody(() => obtainPostBody((body) => postReply(body)))
+		}
+	}
+
+	function itsAShowThreadPage() {
+		let replyBtnImgQuery = "html > body > center > div > div.page " +
+			"> div > table > tbody > tr > td > a > img[alt=Reply]"
+		let replyBtnImg = document.querySelector(replyBtnImgQuery)
+		let replyUrl = replyBtnImg.parentElement.href
+
+		replyDialog.forumThreadVisited(replyUrl)
+	}
+
+	/**
+	 * On newreply.php page, detect whether previous submission was throttled.
+	 * Return true or false.
+	 */
+	function isThrottled() {
+		let errorTitle = "The following errors occurred with your submission"
+
+		for (let candidate of document.querySelectorAll(".tcat")) {
+			if (candidate.innerText.includes(errorTitle)) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	function scrollToForm() {
+		let form = document.querySelector("form[name=vbform] .smallfont a")
+		form.scrollIntoView()
+	}
+
+	function waitForReplyBody(callback) {
+		replyDialog.isNextPostAvailable((bool) => {
+			if (bool) {
+				callback()
+			} else {
+				setTimeout(() => { waitForReplyBody(callback) }, 100)
+			}
+		})
+	}
+
+	function obtainPostBody(callback) {
+		replyDialog.obtainNextPost(callback)
+	}
+
+	function postReply(postBody) {
+		let msgArea = document.querySelector("textarea[name=message]")
+		let submitBtn = document.querySelector("input[name=sbutton]")
+
+		msgArea.value = postBody
+		submitBtn.click()
 	}
 })()

--- a/src/web/ssc.js
+++ b/src/web/ssc.js
@@ -3,4 +3,29 @@
 // @run-at document-end
 // ==/UserScript==
 
-alert("hello")
+(function(){
+	var replyDialog
+
+	console.log("Connecting to Fotorelacjonusz…")
+	initWebChannel()
+
+	/**
+	 * Waits till QWebChannel constructor is available (script load order is
+	 * quite random), and then creates a new instance, passing channelReady
+	 * function as a callback.
+	 */
+	function initWebChannel() {
+		if (typeof(QWebChannel) === "function") {
+			new QWebChannel(qt.webChannelTransport, channelReady)
+		} else {
+			setTimeout(initWebChannel, 50)
+		}
+	}
+
+	function channelReady(channel) {
+		console.log("Established connection to Fotorelacjonusz.")
+
+		replyDialog = channel.objects.replyDialog
+		replyDialog.forumPageLoaded(location.href)
+	}
+})()

--- a/src/widgets/replydialog.cpp
+++ b/src/widgets/replydialog.cpp
@@ -62,15 +62,11 @@ ReplyDialog::ReplyDialog(QSettings &settings, QList<AbstractImage *> imageList, 
 	timer.setInterval(50);
 	connect(&timer, SIGNAL(timeout()), this, SLOT(tick()));
 
-	QWebSettings::globalSettings()->setAttribute(QWebSettings::PluginsEnabled, false);
-	QWebSettings::globalSettings()->setAttribute(QWebSettings::AutoLoadImages, true);
 	connect(ui->webView, SIGNAL(loadProgress(int)), this, SLOT(loadProgress(int)));
 
-	frame = ui->webView->page()->mainFrame();
+	frame = ui->webView->page();
 	QNetworkDiskCache *cache = new QNetworkDiskCache();
 	cache->setCacheDirectory(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));
-	ui->webView->page()->networkAccessManager()->setCache(cache);
-	ui->webView->page()->networkAccessManager()->setCookieJar(new NetworkCookieJar());
 }
 
 ReplyDialog::~ReplyDialog()
@@ -192,6 +188,8 @@ void ReplyDialog::reject()
 	done(Rejected);
 }
 
+// Deliberately to remove.
+#if 0
 bool ReplyDialog::isElement(QString query, QString *variable, int up, QString attr) const
 {
 	if (variable && !variable->isEmpty())
@@ -211,6 +209,7 @@ bool ReplyDialog::isElementRemove(QString query, QString *variable, QString patt
 {
 	return isElement(query, variable, 0, attr) && !(*variable = variable->remove(QRegExp(pattern)).trimmed()).isEmpty();
 }
+#endif
 
 void ReplyDialog::startTimer()
 {
@@ -246,6 +245,7 @@ void ReplyDialog::loadProgress(int progress)
 void ReplyDialog::parseThread(int progress)
 {
 	Q_UNUSED(progress);
+#if 0
 //	qDebug() << "parseThread()" << ui->webView->url() << progress;
 //	qDebug() << "parseThread()" << posts.progress() << posts.total();
 
@@ -320,11 +320,13 @@ void ReplyDialog::parseThread(int progress)
 	qDebug() << "parseThread()" << "przechodzę do formularza\n";
 	posts.setFormat(tr("Przechodzę do formularza... %p%"));
 	ui->webView->load(QString(SSC_HOST) + "/" + replyLink);
+#endif
 }
 
 void ReplyDialog::sendPost(int progress)
 {
 	Q_UNUSED(progress);
+#if 0
 	QWebElement title = frame->findFirstElement("input[name=title]");
 	QWebElement message = frame->findFirstElement("textarea[name=message]");
 	QWebElement submit = frame->findFirstElement("input[name=sbutton]");
@@ -361,6 +363,7 @@ void ReplyDialog::sendPost(int progress)
 	delegate = &ReplyDialog::parseThread;
 	posts.setFormat(tr("Wysyłam posta... %p%"));
 	submit.evaluateJavaScript("this.click()");
+#endif
 }
 
 void ReplyDialog::on_hideInfoButton_clicked()

--- a/src/widgets/replydialog.cpp
+++ b/src/widgets/replydialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_replydialog.h"
 #include "settings/settingsdialog.h"
 #include "uploaders/abstractuploader.h"
+#include "embeddedjavascript.h"
 #include "networkcookiejar.h"
 
 #include <QWebEnginePage>
@@ -11,6 +12,7 @@
 #include <QNetworkDiskCache>
 #include <QDesktopServices>
 #include <QBuffer>
+#include <QWebChannel>
 #include <QtCore/qmath.h>
 
 #define ALL_IMAGES_PROGRESS_MULTIPLIER 10000
@@ -65,6 +67,10 @@ ReplyDialog::ReplyDialog(QSettings &settings, QList<AbstractImage *> imageList, 
 	connect(ui->webView, SIGNAL(loadProgress(int)), this, SLOT(loadProgress(int)));
 
 	frame = ui->webView->page();
+
+	frame->setWebChannel(&webChannel, EmbeddedJavascript::worldId);
+	webChannel.registerObject("replyDialog", this);
+
 	QNetworkDiskCache *cache = new QNetworkDiskCache();
 	cache->setCacheDirectory(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));
 }
@@ -88,6 +94,11 @@ QString ReplyDialog::threadId() const
 QString ReplyDialog::threadTitle() const
 {
 	return m_threadTitle;
+}
+
+void ReplyDialog::forumPageLoaded(QString url)
+{
+	qDebug() << "Browser on page" << url;
 }
 
 void ReplyDialog::appendTable(QString cell0, QString cell1)

--- a/src/widgets/replydialog.cpp
+++ b/src/widgets/replydialog.cpp
@@ -199,29 +199,6 @@ void ReplyDialog::reject()
 	done(Rejected);
 }
 
-// Deliberately to remove.
-#if 0
-bool ReplyDialog::isElement(QString query, QString *variable, int up, QString attr) const
-{
-	if (variable && !variable->isEmpty())
-		return true;
-	QWebElement element = frame->findFirstElement(query);
-	if (element.isNull())
-		return false;
-	for (int i = 0; i < up; ++i)
-		element = element.parent();
-	if (variable)
-		*variable = attr.isEmpty() ? element.toPlainText() : element.attribute(attr);
-	qDebug() << "jest element" << (variable ? *variable : 0);
-	return true;
-}
-
-bool ReplyDialog::isElementRemove(QString query, QString *variable, QString pattern, QString attr) const
-{
-	return isElement(query, variable, 0, attr) && !(*variable = variable->remove(QRegExp(pattern)).trimmed()).isEmpty();
-}
-#endif
-
 void ReplyDialog::startTimer()
 {
 	time.restart();

--- a/src/widgets/replydialog.cpp
+++ b/src/widgets/replydialog.cpp
@@ -4,8 +4,7 @@
 #include "uploaders/abstractuploader.h"
 #include "networkcookiejar.h"
 
-#include <QWebFrame>
-#include <QWebElement>
+#include <QWebEnginePage>
 #include <QDebug>
 #include <QMessageBox>
 #include <QNetworkCookieJar>

--- a/src/widgets/replydialog.h
+++ b/src/widgets/replydialog.h
@@ -50,10 +50,6 @@ protected slots:
 private slots:
 	void startTimer();
 	void tick();
-	void loadProgress(int progress = 0);
-
-	void parseThread(int progress);
-	void sendPost(int progress);
 
 	void on_hideInfoButton_clicked();
 
@@ -70,8 +66,6 @@ private:
 
 	QString m_threadId, m_threadTitle;
 	QString userName;
-
-	void (ReplyDialog::*delegate)(int);
 
 	QTimer timer;
 	PostItem *nextPost;

--- a/src/widgets/replydialog.h
+++ b/src/widgets/replydialog.h
@@ -38,8 +38,8 @@ protected slots:
 	void reject();
 
 private slots:
-	bool isElement(QString query, QString *variable = 0, int up = 0, QString attr = QString()) const;
-	bool isElementRemove(QString query, QString *variable, QString pattern, QString attr = QString()) const;
+//	bool isElement(QString query, QString *variable = 0, int up = 0, QString attr = QString()) const;
+//	bool isElementRemove(QString query, QString *variable, QString pattern, QString attr = QString()) const;
 
 	void startTimer();
 	void tick();

--- a/src/widgets/replydialog.h
+++ b/src/widgets/replydialog.h
@@ -32,6 +32,12 @@ public:
 
 public slots:
 	void forumPageLoaded(QString url);
+	void forumThreadVisited(QString replyUrl);
+	void forumReplySubmissionFailed();
+
+public:
+	Q_INVOKABLE bool isNextPostAvailable();
+	Q_INVOKABLE QString obtainNextPost();
 
 protected slots:
 	void appendTable(QString cell0, QString cell1);

--- a/src/widgets/replydialog.h
+++ b/src/widgets/replydialog.h
@@ -48,9 +48,6 @@ protected slots:
 	void reject();
 
 private slots:
-//	bool isElement(QString query, QString *variable = 0, int up = 0, QString attr = QString()) const;
-//	bool isElementRemove(QString query, QString *variable, QString pattern, QString attr = QString()) const;
-
 	void startTimer();
 	void tick();
 	void loadProgress(int progress = 0);

--- a/src/widgets/replydialog.h
+++ b/src/widgets/replydialog.h
@@ -4,11 +4,11 @@
 #include <QDialog>
 #include <QTimer>
 #include <QTime>
+#include <QWebEnginePage>
 #include "progresscontainer.h"
 #include "abstractimage.h"
 #include "postwidget.h"
 
-class QWebFrame;
 class SettingsDialog;
 class AbstractUploader;
 class QSettings;
@@ -53,7 +53,7 @@ private slots:
 private:
 	Ui::ReplyDialog *ui;
 	QSettings &settings;
-	QWebFrame *frame;
+	QWebEnginePage *frame;
 	AbstractUploader *const uploader;
 
 	ProgressContainer<AbstractImage> images;

--- a/src/widgets/replydialog.h
+++ b/src/widgets/replydialog.h
@@ -5,6 +5,7 @@
 #include <QTimer>
 #include <QTime>
 #include <QWebEnginePage>
+#include <QWebChannel>
 #include "progresscontainer.h"
 #include "abstractimage.h"
 #include "postwidget.h"
@@ -28,6 +29,9 @@ public:
 	int latestPostedImageNumber() const;
 	QString threadId() const;
 	QString threadTitle() const;
+
+public slots:
+	void forumPageLoaded(QString url);
 
 protected slots:
 	void appendTable(QString cell0, QString cell1);
@@ -69,6 +73,8 @@ private:
 	QTimer timer;
 	PostItem *nextPost;
 	QTime time;
+
+	QWebChannel webChannel;
 
 	static const QString likePostId;
 };

--- a/src/widgets/replydialog.ui
+++ b/src/widgets/replydialog.ui
@@ -73,7 +73,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWebView" name="webView">
+        <widget class="QWebEngineView" name="webView">
          <property name="url">
           <url>
            <string>about:blank</string>
@@ -183,9 +183,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QWebView</class>
+   <class>QWebEngineView</class>
    <extends>QWidget</extends>
-   <header>QtWebKit/QWebView</header>
+   <header>QWebEngineView</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/webscripts.qrc
+++ b/webscripts.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>src/web/ssc.js</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
* Remove WebKit Qt module, add WebEngine.
* Implement an easy way to inject client-side scripts to an embedded Chromium browser.
* Implement communication between client-side scripts and C++ application over web channel.
* Rewrite webpage manipulation logic in JavaScript in order to bring WebEngine compatibility.

At this point, Fotorelacjonusz is compatible with Qt 5.12 (current latest).