### PR TITLE
Ignore untracked files in submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "third-party/quazip"]
 	path = third-party/quazip
 	url = https://github.com/stachenov/quazip.git
+	ignore = untracked


### PR DESCRIPTION
Ignore presence of untracked files in submodules, so that they don't pollute results of `git status` in the main repository.