### PR TITLE
Disable proxy settings

### DIFF
--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -17,13 +17,13 @@
 #define ENUM_STR(Enum, Var) QString(metaObject()->enumerator(metaObject()->indexOfEnumerator(#Enum)).valueToKey(Var))
 #define M(x) #x
 
-SettingsDialog *SettingsDialog::objectInstance = 0;
+SettingsDialog *SettingsDialog::objectInstance = nullptr;
 
 SettingsDialog::SettingsDialog(QWidget *parent, QSettings &settings) :
 	QDialog(parent),
 	SettingsManager(settings),
 	ui(new Ui::SettingsDialog),
-	m_uploader(0),
+	m_uploader(nullptr),
 	m_settings(settings),
 	osmDialog(settings, this)
 {
@@ -115,7 +115,7 @@ SettingsDialog::SettingsDialog(QWidget *parent, QSettings &settings) :
 
 SettingsDialog::~SettingsDialog()
 {
-	objectInstance = 0;
+	objectInstance = nullptr;
 	delete m_uploader;
 	delete ui;
 }

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -1169,6 +1169,21 @@ Można do tego folderu dodawać lub usuwać z niego pliki, zmiany będą widoczn
             </property>
            </widget>
           </item>
+          <item row="5" column="0" colspan="2">
+           <widget class="QLabel" name="label">
+            <property name="font">
+             <font>
+              <pointsize>24</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>ZEPSUTE!</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/settings/settingsmanager.cpp
+++ b/src/settings/settingsmanager.cpp
@@ -104,6 +104,14 @@ void SettingsManager::save(AbstractInput *singleInput)
 	QSet<Listener> listeners; // call each listener only once when multiple options changed
 	foreach (AbstractInput *input, singleInput ? QList<AbstractInput *>() << singleInput : inputs)
 	{
+		// FIXME Something is terribly wrong with one of the proxy settings, probably proxy/pass.
+		// Application crashes when saving that setting somewhere in condition below:
+		// (input->toVariant() == settings.value(input->key, input->defaultVal))
+		if (input->key.startsWith("proxy/"))
+		{
+			continue;
+		}
+
 		if (input->toVariant() == settings.value(input->key, input->defaultVal))
 		{
 			input->wasChanged = false;

--- a/src/settings/settingsmanager.h
+++ b/src/settings/settingsmanager.h
@@ -197,13 +197,13 @@ public:
 		return (inputs << new Input<T>(key, object, defaultVal)).last(); // 0, 0,
 	}
 
-	void connectMany(QObject *receiver, const char *member, AbstractField *f0, AbstractField *f1 = 0,
-					 AbstractField *f2 = 0, AbstractField *f3 = 0, AbstractField *f4 = 0, AbstractField *f5 = 0,
-					 AbstractField *f6 = 0, AbstractField *f7 = 0, AbstractField *f8 = 0, AbstractField *f9 = 0);
+	void connectMany(QObject *receiver, const char *member, AbstractField *f0, AbstractField *f1 = nullptr,
+					 AbstractField *f2 = nullptr, AbstractField *f3 = nullptr, AbstractField *f4 = nullptr, AbstractField *f5 = nullptr,
+					 AbstractField *f6 = nullptr, AbstractField *f7 = nullptr, AbstractField *f8 = nullptr, AbstractField *f9 = nullptr);
 
 public:
-	void load(AbstractInput *singleInput = 0);
-	void save(AbstractInput *singleInput = 0);
+	void load(AbstractInput *singleInput = nullptr);
+	void save(AbstractInput *singleInput = nullptr);
 
 private:
 	QSettings &settings;


### PR DESCRIPTION
Something is terribly wrong with settings, proxy settings in particular.  Saving them crashes a whole application in a strange way.

Let's disable them for now. Thanks to that, remaining settings work correctly.