### PR TITLE
Fix translations

### DIFF
--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -701,28 +701,33 @@ If you don&apos;t want your password stored leave this field empty, application 
 <context>
     <name>Overlay</name>
     <message>
+        <location filename="src/settings/overlay.cpp" line="44"/>
         <source>kmz.open(): %1</source>
-        <translation type="vanished">kmz.open(): %1</translation>
+        <translation>kmz.open(): %1</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="49"/>
         <source>file.open(): %1</source>
-        <translation type="vanished">file.open(): %1</translation>
+        <translation>file.open(): %1</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="52"/>
         <source>file.close(): %1</source>
-        <translation type="vanished">file.close(): %1</translation>
+        <translation>file.close(): %1</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="56"/>
         <source>kmz.close(): %1</source>
-        <translation type="vanished">kmz.close(): %1</translation>
+        <translation>kmz.close(): %1</translation>
     </message>
     <message>
         <source>Brak pliku %1</source>
         <translation type="obsolete">No %1 file</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="64"/>
         <source>Niepoprawna składnia kml</source>
-        <translation type="vanished">Kml syntax error</translation>
+        <translation>Kml syntax error</translation>
     </message>
     <message>
         <source>Brak tagu w pliku kml</source>
@@ -737,71 +742,86 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="obsolete">Map file loading failed</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="35"/>
         <source>To nie jest plik podkładu mapowego.</source>
-        <translation type="vanished">This is not an overlay file.</translation>
+        <translation>This is not an overlay file.</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="60"/>
         <source>Brak pliku &apos;%1&apos;</source>
-        <translation type="vanished">No &apos;%1&apos; file</translation>
+        <translation>No &apos;%1&apos; file</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="67"/>
         <source>Brak tagu kml i/lub podrzędnego w pliku kml</source>
-        <translation type="vanished">No kml and/or child tag in kml file</translation>
+        <translation>No kml and/or child tag in kml file</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="82"/>
         <source>Brak tagu Folder lub GroundOverlay</source>
-        <translation type="vanished">No Folder nor GroundOverlay tag</translation>
+        <translation>No Folder nor GroundOverlay tag</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="94"/>
         <source>kmr.open(): %1</source>
-        <translation type="vanished">kmr.open(): %1</translation>
+        <translation>kmr.open(): %1</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="97"/>
         <source>outFileKml.open(): %1</source>
-        <translation type="vanished">outFileKml.open(): %1</translation>
+        <translation>outFileKml.open(): %1</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="100"/>
         <source>outFileKml.close(): %1</source>
-        <translation type="vanished">outFileKml.close(): %1</translation>
+        <translation>outFileKml.close(): %1</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="105"/>
         <source>outFileMap.open(): %1</source>
-        <translation type="vanished">outFileMap.open(): %1</translation>
+        <translation>outFileMap.open(): %1</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="106"/>
         <source>outFileMap.write(): Błąd zapisu danych do archiwum</source>
-        <translation type="vanished">outFileMap.write(): Error while writing data to archive</translation>
+        <translation>outFileMap.write(): Error while writing data to archive</translation>
     </message>
     <message>
         <source>map.save(): Błąd zapisu pixmapy do archiwum</source>
         <translation type="obsolete">map.save(): Error while saving pixmap in archive</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="108"/>
         <source>outFileMap.close(): %1</source>
-        <translation type="vanished">outFileMap.close(): %1</translation>
+        <translation>outFileMap.close(): %1</translation>
     </message>
     <message>
+        <location filename="src/settings/overlay.cpp" line="112"/>
         <source>kmr.close(): %1</source>
-        <translation type="vanished">kmr.close(): %1</translation>
+        <translation>kmr.close(): %1</translation>
     </message>
 </context>
 <context>
     <name>OverlayImage</name>
     <message>
+        <location filename="src/settings/overlayimage.cpp" line="25"/>
         <source>Brak tagu w pliku kml</source>
-        <translation type="vanished">No tag in kml file</translation>
+        <translation>No tag in kml file</translation>
     </message>
     <message>
+        <location filename="src/settings/overlayimage.cpp" line="43"/>
         <source>Brak pliku &apos;%1&apos; w archiwum kmz</source>
-        <translation type="vanished">No &apos;%1&apos; file in kmz archive</translation>
+        <translation>No &apos;%1&apos; file in kmz archive</translation>
     </message>
     <message>
+        <location filename="src/settings/overlayimage.cpp" line="49"/>
         <source>Nieudane ładowanie pliku z mapą, pamięć wyczerpana?</source>
-        <translation type="vanished">Map file loading failed, memory exhausted?</translation>
+        <translation>Map file loading failed, memory exhausted?</translation>
     </message>
     <message>
+        <location filename="src/settings/overlayimage.cpp" line="57"/>
         <source>Nieudane zapisanie mapy do bufora, pamięć wyczerpana?</source>
-        <translation type="vanished">Saving map to buffor failed, memory exhausted?</translation>
+        <translation>Saving map to buffor failed, memory exhausted?</translation>
     </message>
     <message>
         <source>Brak pliku %1 w archiwum kmz</source>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -195,7 +195,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Zdjęcie %1 zostało obrÃ³cone zgodnie z jego orientacją zapisaną w nagłÃ³wku exif.&lt;br&gt;Czy chcesz obrÃ³cić rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
+        <source>Zdjęcie %1 zostało obrÃ³cone zgodnie z jego orientacją zapisaną w nagłÃ³wku exif.&lt;br&gt;Czy chcesz obrÃ³cić rÃ³wnież oryginalne zdjęcie na dysku?</source>
         <translation type="vanished">Photo %1 was rotated according to its orientation setting in exif.&lt;br&gt;Do you want to rotate the original file as well?</translation>
     </message>
     <message>
@@ -209,7 +209,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Removing position</translation>
     </message>
     <message>
-        <source>Czy usunąć pozycję rÃ³wnieÅ¼ z pliku na dysku?</source>
+        <source>Czy usunąć pozycję rÃ³wnież z pliku na dysku?</source>
         <translation type="vanished">Do you want to remove position from the original file as well?</translation>
     </message>
     <message>
@@ -218,7 +218,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Rotate image</translation>
     </message>
     <message>
-        <source>Czy obrÃ³cić rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
+        <source>Czy obrÃ³cić rÃ³wnież oryginalne zdjęcie na dysku?</source>
         <translation type="vanished">Do you want to rotate the original file as well?</translation>
     </message>
     <message>
@@ -655,7 +655,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">Error</translation>
     </message>
     <message>
-        <source>Nie moÅ¼na otworzyć. Tę fotorelację zapisano inną wersją programu.</source>
+        <source>Nie można otworzyć. Tę fotorelację zapisano inną wersją programu.</source>
         <translation type="vanished">Can not open. This photo report has been saved using application in different version.</translation>
     </message>
     <message>
@@ -664,7 +664,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>This is not a photo report file!</translation>
     </message>
     <message>
-        <source>Fotorelacja nie zawiera Å¼adnego zdjęcia.</source>
+        <source>Fotorelacja nie zawiera żadnego zdjęcia.</source>
         <translation type="vanished">Photo report contains no photo.</translation>
     </message>
     <message>
@@ -1116,12 +1116,12 @@ Error at:
         <translation type="vanished">Error</translation>
     </message>
     <message>
-        <source>Nie moÅ¼na było rozpocząć wysyłania z powodu:
+        <source>Nie można było rozpocząć wysyłania z powodu:
 %1</source>
         <translation type="vanished">Can&apos;t start upload, because: %1</translation>
     </message>
     <message>
-        <source>Zdjęcie %1 juÅ¼ wysłane</source>
+        <source>Zdjęcie %1 już wysłane</source>
         <translation type="vanished">Photo %1 already uploaded</translation>
     </message>
     <message>
@@ -1129,7 +1129,7 @@ Error at:
         <translation type="vanished">Sending %1: %p%</translation>
     </message>
     <message>
-        <source>Nie moÅ¼na było wysłać obrazka %1 z powodu:
+        <source>Nie można było wysłać obrazka %1 z powodu:
 %2</source>
         <translation type="vanished">Photo %1 upload failed: %2</translation>
     </message>
@@ -1237,7 +1237,7 @@ Error at:
         <translation type="vanished">Like this app</translation>
     </message>
     <message>
-        <source>Wygląda na to, Å¼e juÅ¼ polubiłeś program.</source>
+        <source>Wygląda na to, że już polubiłeś program.</source>
         <translation type="vanished">It seems you have already liked this app.</translation>
     </message>
     <message>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -667,10 +667,6 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>Try finishing photo report upload?</translation>
     </message>
     <message>
-        <source>&lt;h3&gt;Fotorelacjonusz&lt;/h3&gt;&lt;br/&gt;Autor: Kamil Ostaszewski&lt;br/&gt;&lt;http://sourceforge.net/projects/fotorelacjonusz&gt;&lt;br/&gt;&lt;br/&gt;Aplikacja wykorzystuje:&lt;br/&gt;Qt (LGPL2)&lt;br/&gt;QuaZIP (LGPL2)&lt;br/&gt;Oxygen theme (LGPL)&lt;br/&gt;&lt;br/&gt;%1</source>
-        <translation type="obsolete">&lt;h3&gt;Fotorelacjonusz&lt;/h3&gt;&lt;br/&gt;Author: Kamil Ostaszewski&lt;br/&gt;&lt;http://sourceforge.net/projects/fotorelacjonusz&gt;&lt;br/&gt;&lt;br/&gt;Application uses:&lt;br/&gt;Qt (LGPL2)&lt;br/&gt;QuaZIP (LGPL2)&lt;br/&gt;Oxygen theme (LGPL)&lt;br/&gt;&lt;br/&gt;%1</translation>
-    </message>
-    <message>
         <location filename="src/widgets/mainwindow.cpp" line="70"/>
         <location filename="src/widgets/mainwindow.cpp" line="125"/>
         <source>Fotorelacje (*.phr)</source>
@@ -890,35 +886,6 @@ If you don&apos;t want your password stored leave this field empty, application 
         <location filename="src/widgets/postwidget.cpp" line="38"/>
         <source>Cdn ...</source>
         <translation>Tbc ...</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <source>%1:%2
-%3
-
-Miejsce błędu:
-%4</source>
-        <translation type="obsolete">%1:%2
-%3
-
-Error at:
-%4</translation>
-    </message>
-    <message>
-        <source>%1
-
-Miejsce błędu:
-%2</source>
-        <translation type="obsolete">%1
-
-Error at:
-%2</translation>
-    </message>
-    <message>
-        <source>Mapa dla wszystkich zdjęć.</source>
-        <translation type="obsolete">Common map.</translation>
     </message>
 </context>
 <context>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -195,7 +195,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Zdjęcie %1 zostaÅo obrÃ³cone zgodnie z jego orientacjÄ&#x85; zapisanÄ&#x85; w nagÅÃ³wku exif.&lt;br&gt;Czy chcesz obrÃ³cić rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
+        <source>Zdjęcie %1 zostaÅo obrÃ³cone zgodnie z jego orientacją zapisaną w nagÅÃ³wku exif.&lt;br&gt;Czy chcesz obrÃ³cić rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
         <translation type="vanished">Photo %1 was rotated according to its orientation setting in exif.&lt;br&gt;Do you want to rotate the original file as well?</translation>
     </message>
     <message>
@@ -209,7 +209,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Removing position</translation>
     </message>
     <message>
-        <source>Czy usunÄ&#x85;ć pozycję rÃ³wnieÅ¼ z pliku na dysku?</source>
+        <source>Czy usunąć pozycję rÃ³wnieÅ¼ z pliku na dysku?</source>
         <translation type="vanished">Do you want to remove position from the original file as well?</translation>
     </message>
     <message>
@@ -352,11 +352,11 @@ Wrong url will make all links corrupted.</translation>
         <translation type="vanished">Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; has access to your data on Imgur.</translation>
     </message>
     <message>
-        <source>BÅÄ&#x85;d</source>
+        <source>BÅąd</source>
         <translation type="vanished">Error</translation>
     </message>
     <message>
-        <source>Podczas kontaktowania się z Imgur wystÄ&#x85;piÅ bÅÄ&#x85;d.</source>
+        <source>Podczas kontaktowania się z Imgur wystąpiÅ bÅąd.</source>
         <translation type="vanished">Error while connecting with Imgur. </translation>
     </message>
 </context>
@@ -651,11 +651,11 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">Open photo report</translation>
     </message>
     <message>
-        <source>BÅÄ&#x85;d</source>
+        <source>BÅąd</source>
         <translation type="vanished">Error</translation>
     </message>
     <message>
-        <source>Nie moÅ¼na otworzyć. Tę fotorelację zapisano innÄ&#x85; wersjÄ&#x85; programu.</source>
+        <source>Nie moÅ¼na otworzyć. Tę fotorelację zapisano inną wersją programu.</source>
         <translation type="vanished">Can not open. This photo report has been saved using application in different version.</translation>
     </message>
     <message>
@@ -761,11 +761,11 @@ If you don&apos;t want your password stored leave this field empty, application 
 <context>
     <name>MessageHandler</name>
     <message>
-        <source>BÅÄ&#x85;d %1 w %2&lt;br/&gt;Wiersz %3, kolumna %4:%5</source>
+        <source>BÅąd %1 w %2&lt;br/&gt;Wiersz %3, kolumna %4:%5</source>
         <translation type="obsolete">Error %1 in %2&lt;br/&gt;Row %3, column %4:%5</translation>
     </message>
     <message>
-        <source>BÅÄ&#x85;d</source>
+        <source>BÅąd</source>
         <translation type="obsolete">Error</translation>
     </message>
 </context>
@@ -842,7 +842,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="obsolete">No %1 file in kmz archive</translation>
     </message>
     <message>
-        <source>Nieudane Åadowanie pliku z mapÄ&#x85;</source>
+        <source>Nieudane Åadowanie pliku z mapą</source>
         <translation type="obsolete">Map file loading failed</translation>
     </message>
     <message>
@@ -878,11 +878,11 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">outFileMap.open(): %1</translation>
     </message>
     <message>
-        <source>outFileMap.write(): BÅÄ&#x85;d zapisu danych do archiwum</source>
+        <source>outFileMap.write(): BÅąd zapisu danych do archiwum</source>
         <translation type="vanished">outFileMap.write(): Error while writing data to archive</translation>
     </message>
     <message>
-        <source>map.save(): BÅÄ&#x85;d zapisu pixmapy do archiwum</source>
+        <source>map.save(): BÅąd zapisu pixmapy do archiwum</source>
         <translation type="obsolete">map.save(): Error while saving pixmap in archive</translation>
     </message>
     <message>
@@ -905,7 +905,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">No &apos;%1&apos; file in kmz archive</translation>
     </message>
     <message>
-        <source>Nieudane Åadowanie pliku z mapÄ&#x85;, pamięć wyczerpana?</source>
+        <source>Nieudane Åadowanie pliku z mapą, pamięć wyczerpana?</source>
         <translation type="vanished">Map file loading failed, memory exhausted?</translation>
     </message>
     <message>
@@ -917,7 +917,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="obsolete">No %1 file in kmz archive</translation>
     </message>
     <message>
-        <source>Nieudane Åadowanie pliku z mapÄ&#x85;</source>
+        <source>Nieudane Åadowanie pliku z mapą</source>
         <translation type="obsolete">Map file loading failed</translation>
     </message>
 </context>
@@ -1104,19 +1104,19 @@ Error at:
         <translation>All photos: %p%</translation>
     </message>
     <message>
-        <source>Czekam na wybranie wÄ&#x85;tku...</source>
+        <source>Czekam na wybranie wątku...</source>
         <translation type="vanished">Waiting for thread selection...</translation>
     </message>
     <message>
-        <source>Przechodzę do wÄ&#x85;tku...</source>
+        <source>Przechodzę do wątku...</source>
         <translation type="vanished">Navigating to thread...</translation>
     </message>
     <message>
-        <source>BÅÄ&#x85;d</source>
+        <source>BÅąd</source>
         <translation type="vanished">Error</translation>
     </message>
     <message>
-        <source>Nie moÅ¼na byÅo rozpoczÄ&#x85;ć wysyÅania z powodu:
+        <source>Nie moÅ¼na byÅo rozpocząć wysyÅania z powodu:
 %1</source>
         <translation type="vanished">Can&apos;t start upload, because: %1</translation>
     </message>
@@ -1237,7 +1237,7 @@ Error at:
         <translation type="vanished">Like this app</translation>
     </message>
     <message>
-        <source>WyglÄ&#x85;da na to, Å¼e juÅ¼ polubiÅeÅ program.</source>
+        <source>Wygląda na to, Å¼e juÅ¼ polubiÅeÅ program.</source>
         <translation type="vanished">It seems you have already liked this app.</translation>
     </message>
     <message>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -661,17 +661,6 @@ If you don&apos;t want your password stored leave this field empty, application 
     </message>
 </context>
 <context>
-    <name>MessageHandler</name>
-    <message>
-        <source>Błąd %1 w %2&lt;br/&gt;Wiersz %3, kolumna %4:%5</source>
-        <translation type="obsolete">Error %1 in %2&lt;br/&gt;Row %3, column %4:%5</translation>
-    </message>
-    <message>
-        <source>Błąd</source>
-        <translation type="obsolete">Error</translation>
-    </message>
-</context>
-<context>
     <name>OSMLayerDialog</name>
     <message>
         <location filename="src/settings/osmlayerdialog.ui" line="14"/>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -1080,14 +1080,6 @@ Error at:
         <source>Wysyłam posta... %p%</source>
         <translation type="unfinished">Sending post... %p%</translation>
     </message>
-    <message>
-        <source>Lubię ten program</source>
-        <translation type="vanished">Like this app</translation>
-    </message>
-    <message>
-        <source>Wygląda na to, że już polubiłeś program.</source>
-        <translation type="vanished">It seems you have already liked this app.</translation>
-    </message>
 </context>
 <context>
     <name>SettingsDialog</name>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -143,7 +143,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <source>Nie udaÅo się ustaliÄ czasu UTC poprzez protokÃ³Å NTP.</source>
+        <source>Nie udaÅo się ustalić czasu UTC poprzez protokÃ³Å NTP.</source>
         <translation type="vanished">Quering UTC time with NTP protocol failed.</translation>
     </message>
     <message>
@@ -195,7 +195,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Zdjęcie %1 zostaÅo obrÃ³cone zgodnie z jego orientacjÄ&#x85; zapisanÄ&#x85; w nagÅÃ³wku exif.&lt;br&gt;Czy chcesz obrÃ³ciÄ rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
+        <source>Zdjęcie %1 zostaÅo obrÃ³cone zgodnie z jego orientacjÄ&#x85; zapisanÄ&#x85; w nagÅÃ³wku exif.&lt;br&gt;Czy chcesz obrÃ³cić rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
         <translation type="vanished">Photo %1 was rotated according to its orientation setting in exif.&lt;br&gt;Do you want to rotate the original file as well?</translation>
     </message>
     <message>
@@ -209,7 +209,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Removing position</translation>
     </message>
     <message>
-        <source>Czy usunÄ&#x85;Ä pozycję rÃ³wnieÅ¼ z pliku na dysku?</source>
+        <source>Czy usunÄ&#x85;ć pozycję rÃ³wnieÅ¼ z pliku na dysku?</source>
         <translation type="vanished">Do you want to remove position from the original file as well?</translation>
     </message>
     <message>
@@ -218,7 +218,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Rotate image</translation>
     </message>
     <message>
-        <source>Czy obrÃ³ciÄ rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
+        <source>Czy obrÃ³cić rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
         <translation type="vanished">Do you want to rotate the original file as well?</translation>
     </message>
     <message>
@@ -279,7 +279,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="vanished">Credits reset</translation>
     </message>
     <message>
-        <source>PozostaÅa liczba kredytÃ³w: %1 nie wystarczy na upload %2 zdjęÄ. Zredukuj liczbę zdjęÄ do %3 i sprÃ³buj jeszcze raz.</source>
+        <source>PozostaÅa liczba kredytÃ³w: %1 nie wystarczy na upload %2 zdjęć. Zredukuj liczbę zdjęć do %3 i sprÃ³buj jeszcze raz.</source>
         <translation type="vanished">Remaining credits number: %1 is not enough for uploading %2 images. Decrease image number to %3 and try again.</translation>
     </message>
 </context>
@@ -655,7 +655,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">Error</translation>
     </message>
     <message>
-        <source>Nie moÅ¼na otworzyÄ. Tę fotorelację zapisano innÄ&#x85; wersjÄ&#x85; programu.</source>
+        <source>Nie moÅ¼na otworzyć. Tę fotorelację zapisano innÄ&#x85; wersjÄ&#x85; programu.</source>
         <translation type="vanished">Can not open. This photo report has been saved using application in different version.</translation>
     </message>
     <message>
@@ -677,7 +677,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>Once more</translation>
     </message>
     <message>
-        <source>Czy sprÃ³bowaÄ dokoÅczyÄ wysyÅanie fotorelacji?</source>
+        <source>Czy sprÃ³bować dokoÅczyć wysyÅanie fotorelacji?</source>
         <translation type="vanished">Try finishing photo report upload?</translation>
     </message>
     <message>
@@ -905,11 +905,11 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">No &apos;%1&apos; file in kmz archive</translation>
     </message>
     <message>
-        <source>Nieudane Åadowanie pliku z mapÄ&#x85;, pamięÄ wyczerpana?</source>
+        <source>Nieudane Åadowanie pliku z mapÄ&#x85;, pamięć wyczerpana?</source>
         <translation type="vanished">Map file loading failed, memory exhausted?</translation>
     </message>
     <message>
-        <source>Nieudane zapisanie mapy do bufora, pamięÄ wyczerpana?</source>
+        <source>Nieudane zapisanie mapy do bufora, pamięć wyczerpana?</source>
         <translation type="vanished">Saving map to buffor failed, memory exhausted?</translation>
     </message>
     <message>
@@ -959,7 +959,7 @@ Treść błędu:
         <source>%1:%2
 %3
 
-TreÅÄ bÅędu:
+TreÅć bÅędu:
 %4</source>
         <translation type="vanished">%1:%2
 %3
@@ -1000,7 +1000,7 @@ Error at:
         <translation type="unfinished">Error while loading map data.</translation>
     </message>
     <message>
-        <source>Mapa dla wszystkich zdjęÄ.</source>
+        <source>Mapa dla wszystkich zdjęć.</source>
         <translation type="obsolete">Common map.</translation>
     </message>
     <message>
@@ -1116,7 +1116,7 @@ Error at:
         <translation type="vanished">Error</translation>
     </message>
     <message>
-        <source>Nie moÅ¼na byÅo rozpoczÄ&#x85;Ä wysyÅania z powodu:
+        <source>Nie moÅ¼na byÅo rozpoczÄ&#x85;ć wysyÅania z powodu:
 %1</source>
         <translation type="vanished">Can&apos;t start upload, because: %1</translation>
     </message>
@@ -1129,7 +1129,7 @@ Error at:
         <translation type="vanished">Sending %1: %p%</translation>
     </message>
     <message>
-        <source>Nie moÅ¼na byÅo wysÅaÄ obrazka %1 z powodu:
+        <source>Nie moÅ¼na byÅo wysÅać obrazka %1 z powodu:
 %2</source>
         <translation type="vanished">Photo %1 upload failed: %2</translation>
     </message>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -245,29 +245,6 @@ Wrong url will make all links corrupted.</translation>
     </message>
 </context>
 <context>
-    <name>ImgurAnonyUploader</name>
-    <message>
-        <source>Form</source>
-        <translation type="vanished">Form</translation>
-    </message>
-    <message>
-        <source>Kredyty na użytkownika</source>
-        <translation type="vanished">User credits</translation>
-    </message>
-    <message>
-        <source>Kredyty na aplikację</source>
-        <translation type="vanished">Application credits</translation>
-    </message>
-    <message>
-        <source>Odnowienie kredytów</source>
-        <translation type="vanished">Credits reset</translation>
-    </message>
-    <message>
-        <source>Pozostała liczba kredytów: %1 nie wystarczy na upload %2 zdjęć. Zredukuj liczbę zdjęć do %3 i spróbuj jeszcze raz.</source>
-        <translation type="vanished">Remaining credits number: %1 is not enough for uploading %2 images. Decrease image number to %3 and try again.</translation>
-    </message>
-</context>
-<context>
     <name>ImgurLoginUploader</name>
     <message>
         <location filename="src/uploaders/imgurloginuploader.ui" line="14"/>
@@ -330,13 +307,6 @@ Wrong url will make all links corrupted.</translation>
         <location filename="src/uploaders/isanonuploader.ui" line="16"/>
         <source>Form</source>
         <translation type="unfinished">Form</translation>
-    </message>
-</context>
-<context>
-    <name>IsAnonyUploader</name>
-    <message>
-        <source>Form</source>
-        <translation type="vanished">Form</translation>
     </message>
 </context>
 <context>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -143,7 +143,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <source>Nie udaÅo siÄ ustaliÄ czasu UTC poprzez protokÃ³Å NTP.</source>
+        <source>Nie udaÅo się ustaliÄ czasu UTC poprzez protokÃ³Å NTP.</source>
         <translation type="vanished">Quering UTC time with NTP protocol failed.</translation>
     </message>
     <message>
@@ -195,7 +195,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>ZdjÄcie %1 zostaÅo obrÃ³cone zgodnie z jego orientacjÄ&#x85; zapisanÄ&#x85; w nagÅÃ³wku exif.&lt;br&gt;Czy chcesz obrÃ³ciÄ rÃ³wnieÅ¼ oryginalne zdjÄcie na dysku?</source>
+        <source>Zdjęcie %1 zostaÅo obrÃ³cone zgodnie z jego orientacjÄ&#x85; zapisanÄ&#x85; w nagÅÃ³wku exif.&lt;br&gt;Czy chcesz obrÃ³ciÄ rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
         <translation type="vanished">Photo %1 was rotated according to its orientation setting in exif.&lt;br&gt;Do you want to rotate the original file as well?</translation>
     </message>
     <message>
@@ -209,7 +209,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Removing position</translation>
     </message>
     <message>
-        <source>Czy usunÄ&#x85;Ä pozycjÄ rÃ³wnieÅ¼ z pliku na dysku?</source>
+        <source>Czy usunÄ&#x85;Ä pozycję rÃ³wnieÅ¼ z pliku na dysku?</source>
         <translation type="vanished">Do you want to remove position from the original file as well?</translation>
     </message>
     <message>
@@ -218,7 +218,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Rotate image</translation>
     </message>
     <message>
-        <source>Czy obrÃ³ciÄ rÃ³wnieÅ¼ oryginalne zdjÄcie na dysku?</source>
+        <source>Czy obrÃ³ciÄ rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
         <translation type="vanished">Do you want to rotate the original file as well?</translation>
     </message>
     <message>
@@ -279,7 +279,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="vanished">Credits reset</translation>
     </message>
     <message>
-        <source>PozostaÅa liczba kredytÃ³w: %1 nie wystarczy na upload %2 zdjÄÄ. Zredukuj liczbÄ zdjÄÄ do %3 i sprÃ³buj jeszcze raz.</source>
+        <source>PozostaÅa liczba kredytÃ³w: %1 nie wystarczy na upload %2 zdjęÄ. Zredukuj liczbę zdjęÄ do %3 i sprÃ³buj jeszcze raz.</source>
         <translation type="vanished">Remaining credits number: %1 is not enough for uploading %2 images. Decrease image number to %3 and try again.</translation>
     </message>
 </context>
@@ -330,7 +330,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; uzyskaÅa dostÄp do Twoich danych na Imgur.</source>
+        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; uzyskaÅa dostęp do Twoich danych na Imgur.</source>
         <translation type="vanished">Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; gained access to your data on Imgur.</translation>
     </message>
     <message>
@@ -339,7 +339,7 @@ Wrong url will make all links corrupted.</translation>
         <translation>Authorization denied</translation>
     </message>
     <message>
-        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; nie uzyskaÅa dostÄpu do Twoich danych na Imgur.</source>
+        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; nie uzyskaÅa dostępu do Twoich danych na Imgur.</source>
         <translation type="vanished">Application  &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; didn&apos;t gain access to your data on Imgur.</translation>
     </message>
     <message>
@@ -348,7 +348,7 @@ Wrong url will make all links corrupted.</translation>
         <translation>Ok</translation>
     </message>
     <message>
-        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; ma dostÄp do Twoich danych na Imgur.</source>
+        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; ma dostęp do Twoich danych na Imgur.</source>
         <translation type="vanished">Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; has access to your data on Imgur.</translation>
     </message>
     <message>
@@ -356,7 +356,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="vanished">Error</translation>
     </message>
     <message>
-        <source>Podczas kontaktowania siÄ z Imgur wystÄ&#x85;piÅ bÅÄ&#x85;d.</source>
+        <source>Podczas kontaktowania się z Imgur wystÄ&#x85;piÅ bÅÄ&#x85;d.</source>
         <translation type="vanished">Error while connecting with Imgur. </translation>
     </message>
 </context>
@@ -647,7 +647,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>Delete arrow</translation>
     </message>
     <message>
-        <source>OtwÃ³rz fotorelacjÄ</source>
+        <source>OtwÃ³rz fotorelację</source>
         <translation type="vanished">Open photo report</translation>
     </message>
     <message>
@@ -655,7 +655,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">Error</translation>
     </message>
     <message>
-        <source>Nie moÅ¼na otworzyÄ. TÄ fotorelacjÄ zapisano innÄ&#x85; wersjÄ&#x85; programu.</source>
+        <source>Nie moÅ¼na otworzyÄ. Tę fotorelację zapisano innÄ&#x85; wersjÄ&#x85; programu.</source>
         <translation type="vanished">Can not open. This photo report has been saved using application in different version.</translation>
     </message>
     <message>
@@ -664,11 +664,11 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>This is not a photo report file!</translation>
     </message>
     <message>
-        <source>Fotorelacja nie zawiera Å¼adnego zdjÄcia.</source>
+        <source>Fotorelacja nie zawiera Å¼adnego zdjęcia.</source>
         <translation type="vanished">Photo report contains no photo.</translation>
     </message>
     <message>
-        <source>Zapisz fotorelacjÄ</source>
+        <source>Zapisz fotorelację</source>
         <translation type="vanished">Save photo report</translation>
     </message>
     <message>
@@ -691,11 +691,11 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>Photo reports (*.phr)</translation>
     </message>
     <message>
-        <source>Wybierz zdjÄcia</source>
+        <source>Wybierz zdjęcia</source>
         <translation type="vanished">Choose photos</translation>
     </message>
     <message>
-        <source>ZdjÄcia (*.png *.gif *.jpg *.jpeg)</source>
+        <source>Zdjęcia (*.png *.gif *.jpg *.jpeg)</source>
         <translation type="vanished">Photos (*.png *.gif *.jpg *.jpeg)</translation>
     </message>
     <message>
@@ -854,7 +854,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">No &apos;%1&apos; file</translation>
     </message>
     <message>
-        <source>Brak tagu kml i/lub podrzÄdnego w pliku kml</source>
+        <source>Brak tagu kml i/lub podrzędnego w pliku kml</source>
         <translation type="vanished">No kml and/or child tag in kml file</translation>
     </message>
     <message>
@@ -905,11 +905,11 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">No &apos;%1&apos; file in kmz archive</translation>
     </message>
     <message>
-        <source>Nieudane Åadowanie pliku z mapÄ&#x85;, pamiÄÄ wyczerpana?</source>
+        <source>Nieudane Åadowanie pliku z mapÄ&#x85;, pamięÄ wyczerpana?</source>
         <translation type="vanished">Map file loading failed, memory exhausted?</translation>
     </message>
     <message>
-        <source>Nieudane zapisanie mapy do bufora, pamiÄÄ wyczerpana?</source>
+        <source>Nieudane zapisanie mapy do bufora, pamięÄ wyczerpana?</source>
         <translation type="vanished">Saving map to buffor failed, memory exhausted?</translation>
     </message>
     <message>
@@ -959,7 +959,7 @@ Treść błędu:
         <source>%1:%2
 %3
 
-TreÅÄ bÅÄdu:
+TreÅÄ bÅędu:
 %4</source>
         <translation type="vanished">%1:%2
 %3
@@ -971,7 +971,7 @@ Error message:
         <source>%1:%2
 %3
 
-Miejsce bÅÄdu:
+Miejsce bÅędu:
 %4</source>
         <translation type="obsolete">%1:%2
 %3
@@ -982,7 +982,7 @@ Error at:
     <message>
         <source>%1
 
-Miejsce bÅÄdu:
+Miejsce bÅędu:
 %2</source>
         <translation type="obsolete">%1
 
@@ -1000,7 +1000,7 @@ Error at:
         <translation type="unfinished">Error while loading map data.</translation>
     </message>
     <message>
-        <source>Mapa dla wszystkich zdjÄÄ.</source>
+        <source>Mapa dla wszystkich zdjęÄ.</source>
         <translation type="obsolete">Common map.</translation>
     </message>
     <message>
@@ -1108,7 +1108,7 @@ Error at:
         <translation type="vanished">Waiting for thread selection...</translation>
     </message>
     <message>
-        <source>PrzechodzÄ do wÄ&#x85;tku...</source>
+        <source>Przechodzę do wÄ&#x85;tku...</source>
         <translation type="vanished">Navigating to thread...</translation>
     </message>
     <message>
@@ -1121,7 +1121,7 @@ Error at:
         <translation type="vanished">Can&apos;t start upload, because: %1</translation>
     </message>
     <message>
-        <source>ZdjÄcie %1 juÅ¼ wysÅane</source>
+        <source>Zdjęcie %1 juÅ¼ wysÅane</source>
         <translation type="vanished">Photo %1 already uploaded</translation>
     </message>
     <message>
@@ -1140,7 +1140,7 @@ Error at:
         <translation>seconds</translation>
     </message>
     <message>
-        <source>sekundÄ</source>
+        <source>sekundę</source>
         <comment>1</comment>
         <translation type="vanished">second</translation>
     </message>
@@ -1233,7 +1233,7 @@ Error at:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LubiÄ ten program</source>
+        <source>Lubię ten program</source>
         <translation type="vanished">Like this app</translation>
     </message>
     <message>
@@ -1241,7 +1241,7 @@ Error at:
         <translation type="vanished">It seems you have already liked this app.</translation>
     </message>
     <message>
-        <source>PrzechodzÄ do formularza... %p%</source>
+        <source>Przechodzę do formularza... %p%</source>
         <translation type="vanished">Navigating to form... %p%</translation>
     </message>
     <message>
@@ -1750,7 +1750,7 @@ You can add and remove files from this directory, changes will become visible af
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>ZdjÄcia (*.png *.gif *.jpg *.jpeg)</source>
+        <source>Zdjęcia (*.png *.gif *.jpg *.jpeg)</source>
         <translation type="vanished">Photos (*.png *.gif *.jpg *.jpeg)</translation>
     </message>
 </context>
@@ -1773,7 +1773,7 @@ You can add and remove files from this directory, changes will become visible af
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Podany adres nie koÅczy siÄ na .png</source>
+        <source>Podany adres nie koÅczy się na .png</source>
         <translation type="vanished">Url does not end with .png</translation>
     </message>
     <message>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -2,6 +2,14 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en_US" sourcelanguage="pl_PL">
 <context>
+    <name>AbstractImage</name>
+    <message>
+        <location filename="src/widgets/abstractimage.cpp" line="11"/>
+        <source>mapa.jpg</source>
+        <translation>map.jpg</translation>
+    </message>
+</context>
+<context>
     <name>AbstractUploader</name>
     <message>
         <location filename="src/uploaders/abstractuploader.cpp" line="68"/>
@@ -40,6 +48,27 @@
         <location filename="src/widgets/colormanipulationtoolbar.cpp" line="38"/>
         <source>Gamma</source>
         <translation>Gamma</translation>
+    </message>
+</context>
+<context>
+    <name>Exception</name>
+    <message>
+        <location filename="src/exception.cpp" line="16"/>
+        <source>Błąd</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="src/exception.cpp" line="16"/>
+        <source>%1:%2
+%3
+
+Treść błędu:
+%4</source>
+        <translation>%1:%2
+%3
+
+Error message:
+%4</translation>
     </message>
 </context>
 <context>
@@ -102,6 +131,19 @@ Wrong url will make all links corrupted.</translation>
         <location filename="src/uploaders/ftpuploader.cpp" line="34"/>
         <source>%1 na %2</source>
         <translation>%1 at %2</translation>
+    </message>
+</context>
+<context>
+    <name>GoogleMapsDownloader</name>
+    <message>
+        <location filename="src/downloaders/googlemapsdownloader.cpp" line="42"/>
+        <source>Błąd pobierania mapy: %1 %2</source>
+        <translation>Error while downloading a map: %1 %2</translation>
+    </message>
+    <message>
+        <location filename="src/downloaders/googlemapsdownloader.cpp" line="48"/>
+        <source>Błąd otwierania mapy.</source>
+        <translation>Error while loading map data.</translation>
     </message>
 </context>
 <context>
@@ -853,24 +895,6 @@ If you don&apos;t want your password stored leave this field empty, application 
 <context>
     <name>QObject</name>
     <message>
-        <location filename="src/exception.cpp" line="16"/>
-        <source>Błąd</source>
-        <translation type="unfinished">Error</translation>
-    </message>
-    <message>
-        <location filename="src/exception.cpp" line="16"/>
-        <source>%1:%2
-%3
-
-Treść błędu:
-%4</source>
-        <translation type="unfinished">%1:%2
-%3
-
-Error message:
-%4</translation>
-    </message>
-    <message>
         <source>%1:%2
 %3
 
@@ -893,23 +917,8 @@ Error at:
 %2</translation>
     </message>
     <message>
-        <location filename="src/downloaders/googlemapsdownloader.cpp" line="42"/>
-        <source>Błąd pobierania mapy: %1 %2</source>
-        <translation type="unfinished">Error while downloading a map: %1 %2</translation>
-    </message>
-    <message>
-        <location filename="src/downloaders/googlemapsdownloader.cpp" line="48"/>
-        <source>Błąd otwierania mapy.</source>
-        <translation type="unfinished">Error while loading map data.</translation>
-    </message>
-    <message>
         <source>Mapa dla wszystkich zdjęć.</source>
         <translation type="obsolete">Common map.</translation>
-    </message>
-    <message>
-        <location filename="src/widgets/abstractimage.cpp" line="11"/>
-        <source>mapa.jpg</source>
-        <translation>map.jpg</translation>
     </message>
 </context>
 <context>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -959,7 +959,7 @@ Treść błędu:
         <source>%1:%2
 %3
 
-TreÅć błędu:
+Treść błędu:
 %4</source>
         <translation type="vanished">%1:%2
 %3
@@ -1237,7 +1237,7 @@ Error at:
         <translation type="vanished">Like this app</translation>
     </message>
     <message>
-        <source>Wygląda na to, Å¼e juÅ¼ polubiłeÅ program.</source>
+        <source>Wygląda na to, Å¼e juÅ¼ polubiłeś program.</source>
         <translation type="vanished">It seems you have already liked this app.</translation>
     </message>
     <message>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -208,7 +208,7 @@ Wrong url will make all links corrupted.</translation>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="214"/>
         <source>Nie można załadować zdjęcia. Pamięć wyczerpana?</source>
-        <translation type="unfinished">Can&apos;t load photo.Out of memory? </translation>
+        <translation type="unfinished">Can&apos;t load photo.Out of memory?</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="270"/>
@@ -311,7 +311,7 @@ Wrong url will make all links corrupted.</translation>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="168"/>
         <source>Podczas kontaktowania się z Imgur wystąpił błąd.</source>
-        <translation type="unfinished">Error while connecting with Imgur. </translation>
+        <translation type="unfinished">Error while connecting with Imgur.</translation>
     </message>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="166"/>
@@ -721,7 +721,7 @@ If you don&apos;t want your password stored leave this field empty, application 
     <message>
         <location filename="src/settings/osmlayerdialog.ui" line="49"/>
         <source>Adres musi zawierać zmienne ${x}, ${y}, ${z} oraz kończyć się na .png</source>
-        <translation>Addres has to contain variables ${x}, ${y}, ${z} and it has to end with .png </translation>
+        <translation>Addres has to contain variables ${x}, ${y}, ${z} and it has to end with .png</translation>
     </message>
     <message>
         <location filename="src/settings/osmlayerdialog.ui" line="56"/>
@@ -916,7 +916,7 @@ Error at:
     <message>
         <location filename="src/downloaders/googlemapsdownloader.cpp" line="42"/>
         <source>Błąd pobierania mapy: %1 %2</source>
-        <translation type="unfinished">Error while downloading a map: %1 %2 </translation>
+        <translation type="unfinished">Error while downloading a map: %1 %2</translation>
     </message>
     <message>
         <location filename="src/downloaders/googlemapsdownloader.cpp" line="48"/>
@@ -1470,7 +1470,7 @@ Most probably short time favors post miximg by the forum.</translation>
     <message>
         <location filename="src/settings/settingsdialog.ui" line="738"/>
         <source>Źródło danych Google Maps: &lt;a href=&quot;https://developers.google.com/maps/documentation/staticmaps/&quot;&gt;https://developers.google.com/maps/documentation/staticmaps/&lt;/a&gt;</source>
-        <translation>Google Maps data source:&lt;a href=&quot;https://developers.google.com/maps/documentation/staticmaps/&quot;&gt;https://developers.google.com/maps/documentation/staticmaps/&lt;/a&gt; </translation>
+        <translation>Google Maps data source:&lt;a href=&quot;https://developers.google.com/maps/documentation/staticmaps/&quot;&gt;https://developers.google.com/maps/documentation/staticmaps/&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="src/settings/settingsdialog.ui" line="748"/>
@@ -1652,7 +1652,7 @@ You can add and remove files from this directory, changes will become visible af
     <message>
         <location filename="src/downloaders/tilesdownloader.cpp" line="146"/>
         <source>Błąd pobierania mapy: %1 %2</source>
-        <translation type="unfinished">Error while downloading a map: %1 %2 </translation>
+        <translation type="unfinished">Error while downloading a map: %1 %2</translation>
     </message>
 </context>
 <context>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -99,7 +99,7 @@ Wrong url will make all links corrupted.</translation>
         <translation>Use following folder</translation>
     </message>
     <message>
-        <location filename="src/uploaders/ftpuploader.cpp" line="36"/>
+        <location filename="src/uploaders/ftpuploader.cpp" line="34"/>
         <source>%1 na %2</source>
         <translation>%1 at %2</translation>
     </message>
@@ -1801,7 +1801,7 @@ You can add and remove files from this directory, changes will become visible af
         <translation type="vanished">Own FTP account</translation>
     </message>
     <message>
-        <location filename="src/uploaders/uploaderfactory.cpp" line="51"/>
+        <location filename="src/uploaders/uploaderfactory.cpp" line="47"/>
         <source>Imgur anonimowo</source>
         <translation>Imgur anonymous</translation>
     </message>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -34,7 +34,7 @@
     <message>
         <location filename="src/widgets/colormanipulationtoolbar.cpp" line="28"/>
         <source>Jasność</source>
-        <translation type="unfinished">Brightness</translation>
+        <translation>Brightness</translation>
     </message>
     <message>
         <location filename="src/widgets/colormanipulationtoolbar.cpp" line="38"/>
@@ -140,7 +140,7 @@ Wrong url will make all links corrupted.</translation>
         <location filename="src/widgets/gpxdialog.cpp" line="54"/>
         <location filename="src/widgets/gpxdialog.cpp" line="120"/>
         <source>Błąd</source>
-        <translation type="unfinished">Error</translation>
+        <translation>Error</translation>
     </message>
     <message>
         <location filename="src/widgets/gpxdialog.cpp" line="54"/>
@@ -150,7 +150,7 @@ Wrong url will make all links corrupted.</translation>
     <message>
         <location filename="src/widgets/gpxdialog.cpp" line="117"/>
         <source>Błąd %1 w %2&lt;br/&gt;Wiersz %3, kolumna %4:%5</source>
-        <translation type="unfinished">Error %1 in %2&lt;br/&gt;Row %3, column %4:%5</translation>
+        <translation>Error %1 in %2&lt;br/&gt;Row %3, column %4:%5</translation>
     </message>
     <message>
         <location filename="src/widgets/gpxdialog.cpp" line="141"/>
@@ -168,52 +168,52 @@ Wrong url will make all links corrupted.</translation>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="57"/>
         <source>Nie można załadować zdjęcia do pamięci. Pamięć wyczerpana?</source>
-        <translation type="unfinished">Unable to load an image to the memory. Out of memory?</translation>
+        <translation>Unable to load an image to the memory. Out of memory?</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="76"/>
         <source>Orientacja zdjęcia</source>
-        <translation type="unfinished">Photo orientation</translation>
+        <translation>Photo orientation</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="76"/>
         <source>Zdjęcie %1 zostało obrócone zgodnie z jego orientacją zapisaną w nagłówku exif.&lt;br&gt;Czy chcesz obrócić również oryginalne zdjęcie na dysku?</source>
-        <translation type="unfinished">Photo %1 was rotated according to its orientation setting in exif.&lt;br&gt;Do you want to rotate the original file as well?</translation>
+        <translation>Photo %1 was rotated according to its orientation setting in exif.&lt;br&gt;Do you want to rotate the original file as well?</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="170"/>
         <source>Czy usunąć pozycję również z pliku na dysku?</source>
-        <translation type="unfinished">Do you want to remove position from the original file as well?</translation>
+        <translation>Do you want to remove position from the original file as well?</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="198"/>
         <source>Czy obrócić również oryginalne zdjęcie na dysku?</source>
-        <translation type="unfinished">Do you want to rotate the original file as well?</translation>
+        <translation>Do you want to rotate the original file as well?</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="101"/>
         <source>Podpis zdjęcia</source>
-        <translation type="unfinished">Image caption</translation>
+        <translation>Image caption</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="170"/>
         <source>Usunięcie pozycji</source>
-        <translation type="unfinished">Removing position</translation>
+        <translation>Removing position</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="198"/>
         <source>Obrót zdjęcia</source>
-        <translation type="unfinished">Rotate image</translation>
+        <translation>Rotate image</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="214"/>
         <source>Nie można załadować zdjęcia. Pamięć wyczerpana?</source>
-        <translation type="unfinished">Can&apos;t load photo.Out of memory?</translation>
+        <translation>Can&apos;t load photo.Out of memory?</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="270"/>
         <source>Nie można utworzyć pixmapy ze zdjęcia. Pamięć wyczerpana?</source>
-        <translation type="unfinished">Can&apos;t create pixmap from an image. Out of memory?</translation>
+        <translation>Can&apos;t create pixmap from an image. Out of memory?</translation>
     </message>
 </context>
 <context>
@@ -221,27 +221,27 @@ Wrong url will make all links corrupted.</translation>
     <message>
         <location filename="src/uploaders/imguranonuploader.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished">Form</translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="src/uploaders/imguranonuploader.ui" line="40"/>
         <source>Odnowienie kredytów</source>
-        <translation type="unfinished">Credits reset</translation>
+        <translation>Credits reset</translation>
     </message>
     <message>
         <location filename="src/uploaders/imguranonuploader.ui" line="57"/>
         <source>Kredyty na użytkownika</source>
-        <translation type="unfinished">User credits</translation>
+        <translation>User credits</translation>
     </message>
     <message>
         <location filename="src/uploaders/imguranonuploader.ui" line="67"/>
         <source>Kredyty na aplikację</source>
-        <translation type="unfinished">Application credits</translation>
+        <translation>Application credits</translation>
     </message>
     <message>
         <location filename="src/uploaders/imguranonuploader.cpp" line="98"/>
         <source>Pozostała liczba kredytów: %1 nie wystarczy na upload %2 zdjęć. Zredukuj liczbę zdjęć do %3 i spróbuj jeszcze raz.</source>
-        <translation type="unfinished">Remaining credits number: %1 is not enough for uploading %2 images. Decrease image number to %3 and try again.</translation>
+        <translation>Remaining credits number: %1 is not enough for uploading %2 images. Decrease image number to %3 and try again.</translation>
     </message>
 </context>
 <context>
@@ -268,27 +268,27 @@ Wrong url will make all links corrupted.</translation>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="165"/>
         <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; uzyskała dostęp do Twoich danych na Imgur.</source>
-        <translation type="unfinished">Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; gained access to your data on Imgur.</translation>
+        <translation>Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; gained access to your data on Imgur.</translation>
     </message>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="166"/>
         <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; nie uzyskała dostępu do Twoich danych na Imgur.</source>
-        <translation type="unfinished">Application  &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; didn&apos;t gain access to your data on Imgur.</translation>
+        <translation>Application  &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; didn&apos;t gain access to your data on Imgur.</translation>
     </message>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="167"/>
         <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; ma dostęp do Twoich danych na Imgur.</source>
-        <translation type="unfinished">Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; has access to your data on Imgur.</translation>
+        <translation>Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; has access to your data on Imgur.</translation>
     </message>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="168"/>
         <source>Błąd</source>
-        <translation type="unfinished">Error</translation>
+        <translation>Error</translation>
     </message>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="168"/>
         <source>Podczas kontaktowania się z Imgur wystąpił błąd.</source>
-        <translation type="unfinished">Error while connecting with Imgur.</translation>
+        <translation>Error while connecting with Imgur.</translation>
     </message>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="166"/>
@@ -306,7 +306,7 @@ Wrong url will make all links corrupted.</translation>
     <message>
         <location filename="src/uploaders/isanonuploader.ui" line="16"/>
         <source>Form</source>
-        <translation type="unfinished">Form</translation>
+        <translation>Form</translation>
     </message>
 </context>
 <context>
@@ -652,7 +652,7 @@ If you don&apos;t want your password stored leave this field empty, application 
     <message>
         <location filename="src/widgets/mainwindow.cpp" line="233"/>
         <source>&lt;h3&gt;Fotorelacjonusz&lt;/h3&gt;&lt;br/&gt;Autor: Kamil Ostaszewski&lt;br/&gt;Wersja: %2 (kompilacja %3)&lt;br/&gt;&lt;http://sourceforge.net/projects/fotorelacjonusz&gt;&lt;br/&gt;&lt;br/&gt;Aplikacja wykorzystuje:&lt;br/&gt;Qt (LGPL2)&lt;br/&gt;QtFtp (LGPL2)&lt;br/&gt;QuaZIP (LGPL2)&lt;br/&gt;Oxygen theme (LGPL)&lt;br/&gt;&lt;br/&gt;%1</source>
-        <translation type="unfinished">&lt;h3&gt;Fotorelacjonusz&lt;/h3&gt;&lt;br/&gt;Author: Kamil Ostaszewski&lt;br/&gt;Version: %2 (compilation %3)&lt;br/&gt;&lt;http://sourceforge.net/projects/fotorelacjonusz&gt;&lt;br/&gt;&lt;br/&gt;Application uses:&lt;br/&gt;Qt (LGPL2)&lt;br/&gt;QtFtp (LGPL2)&lt;br/&gt;QuaZIP (LGPL2)&lt;br/&gt;Oxygen theme (LGPL)&lt;br/&gt;&lt;br/&gt;%1</translation>
+        <translation>&lt;h3&gt;Fotorelacjonusz&lt;/h3&gt;&lt;br/&gt;Author: Kamil Ostaszewski&lt;br/&gt;Version: %2 (compilation %3)&lt;br/&gt;&lt;http://sourceforge.net/projects/fotorelacjonusz&gt;&lt;br/&gt;&lt;br/&gt;Application uses:&lt;br/&gt;Qt (LGPL2)&lt;br/&gt;QtFtp (LGPL2)&lt;br/&gt;QuaZIP (LGPL2)&lt;br/&gt;Oxygen theme (LGPL)&lt;br/&gt;&lt;br/&gt;%1</translation>
     </message>
     <message>
         <location filename="src/widgets/mainwindow.cpp" line="249"/>
@@ -690,7 +690,7 @@ If you don&apos;t want your password stored leave this field empty, application 
     <message>
         <location filename="src/settings/osmlayerdialog.cpp" line="89"/>
         <source>Którą warstwę usunąć?</source>
-        <translation type="unfinished">Which layer to remove?</translation>
+        <translation>Which layer to remove?</translation>
     </message>
     <message>
         <location filename="src/settings/osmlayerdialog.cpp" line="89"/>
@@ -910,12 +910,12 @@ Error at:
     <message>
         <location filename="src/widgets/recentthreadsmenu.cpp" line="25"/>
         <source>Kontynuuj numerację</source>
-        <translation type="unfinished">Continue numbering</translation>
+        <translation>Continue numbering</translation>
     </message>
     <message>
         <location filename="src/widgets/recentthreadsmenu.cpp" line="29"/>
         <source>Żaden</source>
-        <translation type="unfinished">None</translation>
+        <translation>None</translation>
     </message>
 </context>
 <context>
@@ -1073,12 +1073,12 @@ Error at:
     <message>
         <location filename="src/widgets/replydialog.cpp" line="299"/>
         <source>Przechodzę do formularza... %p%</source>
-        <translation type="unfinished">Navigating to form... %p%</translation>
+        <translation>Navigating to form... %p%</translation>
     </message>
     <message>
         <location filename="src/widgets/replydialog.cpp" line="353"/>
         <source>Wysyłam posta... %p%</source>
-        <translation type="unfinished">Sending post... %p%</translation>
+        <translation>Sending post... %p%</translation>
     </message>
 </context>
 <context>
@@ -1579,7 +1579,7 @@ You can add and remove files from this directory, changes will become visible af
     <message>
         <location filename="src/settings/settingsdialog.cpp" line="253"/>
         <source>Zdjęcia (*.png *.gif *.jpg *.jpeg)</source>
-        <translation type="unfinished">Photos (*.png *.gif *.jpg *.jpeg)</translation>
+        <translation>Photos (*.png *.gif *.jpg *.jpeg)</translation>
     </message>
 </context>
 <context>
@@ -1588,7 +1588,7 @@ You can add and remove files from this directory, changes will become visible af
         <location filename="src/downloaders/tilesdownloader.cpp" line="31"/>
         <location filename="src/downloaders/tilesdownloader.cpp" line="37"/>
         <source>Błąd</source>
-        <translation type="unfinished">Error</translation>
+        <translation>Error</translation>
     </message>
     <message>
         <location filename="src/downloaders/tilesdownloader.cpp" line="31"/>
@@ -1598,12 +1598,12 @@ You can add and remove files from this directory, changes will become visible af
     <message>
         <location filename="src/downloaders/tilesdownloader.cpp" line="37"/>
         <source>Podany adres nie kończy się na .png</source>
-        <translation type="unfinished">Url does not end with .png</translation>
+        <translation>Url does not end with .png</translation>
     </message>
     <message>
         <location filename="src/downloaders/tilesdownloader.cpp" line="146"/>
         <source>Błąd pobierania mapy: %1 %2</source>
-        <translation type="unfinished">Error while downloading a map: %1 %2</translation>
+        <translation>Error while downloading a map: %1 %2</translation>
     </message>
 </context>
 <context>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -11,12 +11,12 @@
     <message>
         <location filename="src/uploaders/abstractuploader.cpp" line="104"/>
         <source>Podaj hasło</source>
-        <translation type="unfinished">Input password</translation>
+        <translation>Enter password</translation>
     </message>
     <message>
         <location filename="src/uploaders/abstractuploader.cpp" line="104"/>
         <source>Podaj hasło do %1</source>
-        <translation type="unfinished">Input password for %1</translation>
+        <translation>Enter password for %1</translation>
     </message>
     <message>
         <location filename="src/uploaders/abstractuploader.cpp" line="112"/>
@@ -908,12 +908,12 @@ Error at:
     <message>
         <location filename="src/widgets/questionbox.cpp" line="25"/>
         <source>Zapamiętaj na zawsze</source>
-        <translation type="unfinished">Remember always</translation>
+        <translation>Remember permanently</translation>
     </message>
     <message>
         <location filename="src/widgets/questionbox.cpp" line="26"/>
         <source>Zapamiętaj w tej sesji</source>
-        <translation type="unfinished">Remember during this session</translation>
+        <translation>Remember for this session only</translation>
     </message>
 </context>
 <context>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -143,13 +143,9 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <source>Nie udało się ustalić czasu UTC poprzez protokół NTP.</source>
-        <translation type="vanished">Quering UTC time with NTP protocol failed.</translation>
-    </message>
-    <message>
         <location filename="src/widgets/gpxdialog.cpp" line="54"/>
         <source>Nie udało się ustalić czasu UTC poprzez protokół NTP.</source>
-        <translation type="unfinished"></translation>
+        <translation>Quering UTC time with NTP protocol failed.</translation>
     </message>
     <message>
         <location filename="src/widgets/gpxdialog.cpp" line="117"/>
@@ -182,21 +178,17 @@ Wrong url will make all links corrupted.</translation>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="76"/>
         <source>Zdjęcie %1 zostało obrócone zgodnie z jego orientacją zapisaną w nagłówku exif.&lt;br&gt;Czy chcesz obrócić również oryginalne zdjęcie na dysku?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Photo %1 was rotated according to its orientation setting in exif.&lt;br&gt;Do you want to rotate the original file as well?</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="170"/>
         <source>Czy usunąć pozycję również z pliku na dysku?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Do you want to remove position from the original file as well?</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="198"/>
         <source>Czy obrócić również oryginalne zdjęcie na dysku?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zdjęcie %1 zostało obrócone zgodnie z jego orientacją zapisaną w nagłówku exif.&lt;br&gt;Czy chcesz obrócić również oryginalne zdjęcie na dysku?</source>
-        <translation type="vanished">Photo %1 was rotated according to its orientation setting in exif.&lt;br&gt;Do you want to rotate the original file as well?</translation>
+        <translation type="unfinished">Do you want to rotate the original file as well?</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="101"/>
@@ -209,17 +201,9 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Removing position</translation>
     </message>
     <message>
-        <source>Czy usunąć pozycję również z pliku na dysku?</source>
-        <translation type="vanished">Do you want to remove position from the original file as well?</translation>
-    </message>
-    <message>
         <location filename="src/widgets/imagewidget.cpp" line="198"/>
         <source>Obrót zdjęcia</source>
         <translation type="unfinished">Rotate image</translation>
-    </message>
-    <message>
-        <source>Czy obrócić również oryginalne zdjęcie na dysku?</source>
-        <translation type="vanished">Do you want to rotate the original file as well?</translation>
     </message>
     <message>
         <location filename="src/widgets/imagewidget.cpp" line="214"/>
@@ -257,7 +241,7 @@ Wrong url will make all links corrupted.</translation>
     <message>
         <location filename="src/uploaders/imguranonuploader.cpp" line="98"/>
         <source>Pozostała liczba kredytów: %1 nie wystarczy na upload %2 zdjęć. Zredukuj liczbę zdjęć do %3 i spróbuj jeszcze raz.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Remaining credits number: %1 is not enough for uploading %2 images. Decrease image number to %3 and try again.</translation>
     </message>
 </context>
 <context>
@@ -307,17 +291,17 @@ Wrong url will make all links corrupted.</translation>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="165"/>
         <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; uzyskała dostęp do Twoich danych na Imgur.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; gained access to your data on Imgur.</translation>
     </message>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="166"/>
         <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; nie uzyskała dostępu do Twoich danych na Imgur.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Application  &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; didn&apos;t gain access to your data on Imgur.</translation>
     </message>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="167"/>
         <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; ma dostęp do Twoich danych na Imgur.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; has access to your data on Imgur.</translation>
     </message>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="168"/>
@@ -327,11 +311,7 @@ Wrong url will make all links corrupted.</translation>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="168"/>
         <source>Podczas kontaktowania się z Imgur wystąpił błąd.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; uzyskała dostęp do Twoich danych na Imgur.</source>
-        <translation type="vanished">Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; gained access to your data on Imgur.</translation>
+        <translation type="unfinished">Error while connecting with Imgur. </translation>
     </message>
     <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="166"/>
@@ -339,25 +319,9 @@ Wrong url will make all links corrupted.</translation>
         <translation>Authorization denied</translation>
     </message>
     <message>
-        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; nie uzyskała dostępu do Twoich danych na Imgur.</source>
-        <translation type="vanished">Application  &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; didn&apos;t gain access to your data on Imgur.</translation>
-    </message>
-    <message>
         <location filename="src/uploaders/imgurloginuploader.cpp" line="167"/>
         <source>Ok</source>
         <translation>Ok</translation>
-    </message>
-    <message>
-        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; ma dostęp do Twoich danych na Imgur.</source>
-        <translation type="vanished">Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; has access to your data on Imgur.</translation>
-    </message>
-    <message>
-        <source>Błąd</source>
-        <translation type="vanished">Error</translation>
-    </message>
-    <message>
-        <source>Podczas kontaktowania się z Imgur wystąpił błąd.</source>
-        <translation type="vanished">Error while connecting with Imgur. </translation>
     </message>
 </context>
 <context>
@@ -647,16 +611,22 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>Delete arrow</translation>
     </message>
     <message>
+        <location filename="src/widgets/mainwindow.cpp" line="70"/>
         <source>Otwórz fotorelację</source>
-        <translation type="vanished">Open photo report</translation>
+        <translation>Open photo report</translation>
     </message>
     <message>
+        <location filename="src/widgets/mainwindow.cpp" line="88"/>
+        <location filename="src/widgets/mainwindow.cpp" line="94"/>
+        <location filename="src/widgets/mainwindow.cpp" line="122"/>
+        <location filename="src/widgets/mainwindow.cpp" line="198"/>
         <source>Błąd</source>
-        <translation type="vanished">Error</translation>
+        <translation>Error</translation>
     </message>
     <message>
+        <location filename="src/widgets/mainwindow.cpp" line="94"/>
         <source>Nie można otworzyć. Tę fotorelację zapisano inną wersją programu.</source>
-        <translation type="vanished">Can not open. This photo report has been saved using application in different version.</translation>
+        <translation>Can not open. This photo report has been saved using application in different version.</translation>
     </message>
     <message>
         <location filename="src/widgets/mainwindow.cpp" line="88"/>
@@ -664,12 +634,15 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>This is not a photo report file!</translation>
     </message>
     <message>
+        <location filename="src/widgets/mainwindow.cpp" line="122"/>
+        <location filename="src/widgets/mainwindow.cpp" line="198"/>
         <source>Fotorelacja nie zawiera żadnego zdjęcia.</source>
-        <translation type="vanished">Photo report contains no photo.</translation>
+        <translation>Photo report contains no photo.</translation>
     </message>
     <message>
+        <location filename="src/widgets/mainwindow.cpp" line="125"/>
         <source>Zapisz fotorelację</source>
-        <translation type="vanished">Save photo report</translation>
+        <translation>Save photo report</translation>
     </message>
     <message>
         <location filename="src/widgets/mainwindow.cpp" line="213"/>
@@ -677,8 +650,9 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>Once more</translation>
     </message>
     <message>
+        <location filename="src/widgets/mainwindow.cpp" line="213"/>
         <source>Czy spróbować dokończyć wysyłanie fotorelacji?</source>
-        <translation type="vanished">Try finishing photo report upload?</translation>
+        <translation>Try finishing photo report upload?</translation>
     </message>
     <message>
         <source>&lt;h3&gt;Fotorelacjonusz&lt;/h3&gt;&lt;br/&gt;Autor: Kamil Ostaszewski&lt;br/&gt;&lt;http://sourceforge.net/projects/fotorelacjonusz&gt;&lt;br/&gt;&lt;br/&gt;Aplikacja wykorzystuje:&lt;br/&gt;Qt (LGPL2)&lt;br/&gt;QuaZIP (LGPL2)&lt;br/&gt;Oxygen theme (LGPL)&lt;br/&gt;&lt;br/&gt;%1</source>
@@ -691,56 +665,14 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>Photo reports (*.phr)</translation>
     </message>
     <message>
-        <source>Wybierz zdjęcia</source>
-        <translation type="vanished">Choose photos</translation>
-    </message>
-    <message>
-        <source>Zdjęcia (*.png *.gif *.jpg *.jpeg)</source>
-        <translation type="vanished">Photos (*.png *.gif *.jpg *.jpeg)</translation>
-    </message>
-    <message>
-        <location filename="src/widgets/mainwindow.cpp" line="70"/>
-        <source>Otwórz fotorelację</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/widgets/mainwindow.cpp" line="88"/>
-        <location filename="src/widgets/mainwindow.cpp" line="94"/>
-        <location filename="src/widgets/mainwindow.cpp" line="122"/>
-        <location filename="src/widgets/mainwindow.cpp" line="198"/>
-        <source>Błąd</source>
-        <translation type="unfinished">Error</translation>
-    </message>
-    <message>
-        <location filename="src/widgets/mainwindow.cpp" line="94"/>
-        <source>Nie można otworzyć. Tę fotorelację zapisano inną wersją programu.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/widgets/mainwindow.cpp" line="122"/>
-        <location filename="src/widgets/mainwindow.cpp" line="198"/>
-        <source>Fotorelacja nie zawiera żadnego zdjęcia.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/widgets/mainwindow.cpp" line="125"/>
-        <source>Zapisz fotorelację</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="src/widgets/mainwindow.cpp" line="162"/>
         <source>Wybierz zdjęcia</source>
-        <translation type="unfinished"></translation>
+        <translation>Choose photos</translation>
     </message>
     <message>
         <location filename="src/widgets/mainwindow.cpp" line="162"/>
         <source>Zdjęcia (*.png *.gif *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/widgets/mainwindow.cpp" line="213"/>
-        <source>Czy spróbować dokończyć wysyłanie fotorelacji?</source>
-        <translation type="unfinished"></translation>
+        <translation>Photos (*.png *.gif *.jpg *.jpeg)</translation>
     </message>
     <message>
         <location filename="src/widgets/mainwindow.cpp" line="233"/>
@@ -953,15 +885,7 @@ If you don&apos;t want your password stored leave this field empty, application 
 
 Treść błędu:
 %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1:%2
-%3
-
-Treść błędu:
-%4</source>
-        <translation type="vanished">%1:%2
+        <translation type="unfinished">%1:%2
 %3
 
 Error message:
@@ -1104,34 +1028,42 @@ Error at:
         <translation>All photos: %p%</translation>
     </message>
     <message>
+        <location filename="src/widgets/replydialog.cpp" line="37"/>
         <source>Czekam na wybranie wątku...</source>
-        <translation type="vanished">Waiting for thread selection...</translation>
+        <translation>Waiting for thread selection...</translation>
     </message>
     <message>
+        <location filename="src/widgets/replydialog.cpp" line="37"/>
         <source>Przechodzę do wątku...</source>
-        <translation type="vanished">Navigating to thread...</translation>
+        <translation>Navigating to thread...</translation>
     </message>
     <message>
+        <location filename="src/widgets/replydialog.cpp" line="129"/>
+        <location filename="src/widgets/replydialog.cpp" line="159"/>
         <source>Błąd</source>
-        <translation type="vanished">Error</translation>
+        <translation>Error</translation>
     </message>
     <message>
+        <location filename="src/widgets/replydialog.cpp" line="129"/>
         <source>Nie można było rozpocząć wysyłania z powodu:
 %1</source>
-        <translation type="vanished">Can&apos;t start upload, because: %1</translation>
+        <translation>Can&apos;t start upload, because: %1</translation>
     </message>
     <message>
+        <location filename="src/widgets/replydialog.cpp" line="139"/>
         <source>Zdjęcie %1 już wysłane</source>
-        <translation type="vanished">Photo %1 already uploaded</translation>
+        <translation>Photo %1 already uploaded</translation>
     </message>
     <message>
+        <location filename="src/widgets/replydialog.cpp" line="145"/>
         <source>Wysyłam %1: %p%</source>
-        <translation type="vanished">Sending %1: %p%</translation>
+        <translation>Sending %1: %p%</translation>
     </message>
     <message>
+        <location filename="src/widgets/replydialog.cpp" line="159"/>
         <source>Nie można było wysłać obrazka %1 z powodu:
 %2</source>
-        <translation type="vanished">Photo %1 upload failed: %2</translation>
+        <translation>Photo %1 upload failed: %2</translation>
     </message>
     <message>
         <location filename="src/widgets/replydialog.cpp" line="210"/>
@@ -1140,59 +1072,16 @@ Error at:
         <translation>seconds</translation>
     </message>
     <message>
+        <location filename="src/widgets/replydialog.cpp" line="210"/>
         <source>sekundę</source>
         <comment>1</comment>
-        <translation type="vanished">second</translation>
-    </message>
-    <message>
-        <location filename="src/widgets/replydialog.cpp" line="37"/>
-        <source>Przechodzę do wątku...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/widgets/replydialog.cpp" line="37"/>
-        <source>Czekam na wybranie wątku...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/widgets/replydialog.cpp" line="129"/>
-        <location filename="src/widgets/replydialog.cpp" line="159"/>
-        <source>Błąd</source>
-        <translation type="unfinished">Error</translation>
-    </message>
-    <message>
-        <location filename="src/widgets/replydialog.cpp" line="129"/>
-        <source>Nie można było rozpocząć wysyłania z powodu:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/widgets/replydialog.cpp" line="139"/>
-        <source>Zdjęcie %1 już wysłane</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/widgets/replydialog.cpp" line="145"/>
-        <source>Wysyłam %1: %p%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/widgets/replydialog.cpp" line="159"/>
-        <source>Nie można było wysłać obrazka %1 z powodu:
-%2</source>
-        <translation type="unfinished"></translation>
+        <translation>second</translation>
     </message>
     <message>
         <location filename="src/widgets/replydialog.cpp" line="210"/>
         <source>sekundy</source>
         <comment>2</comment>
         <translation>seconds</translation>
-    </message>
-    <message>
-        <location filename="src/widgets/replydialog.cpp" line="210"/>
-        <source>sekundę</source>
-        <comment>1</comment>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="src/widgets/replydialog.cpp" line="211"/>
@@ -1225,12 +1114,12 @@ Error at:
     <message>
         <location filename="src/widgets/replydialog.cpp" line="299"/>
         <source>Przechodzę do formularza... %p%</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Navigating to form... %p%</translation>
     </message>
     <message>
         <location filename="src/widgets/replydialog.cpp" line="353"/>
         <source>Wysyłam posta... %p%</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Sending post... %p%</translation>
     </message>
     <message>
         <source>Lubię ten program</source>
@@ -1239,14 +1128,6 @@ Error at:
     <message>
         <source>Wygląda na to, że już polubiłeś program.</source>
         <translation type="vanished">It seems you have already liked this app.</translation>
-    </message>
-    <message>
-        <source>Przechodzę do formularza... %p%</source>
-        <translation type="vanished">Navigating to form... %p%</translation>
-    </message>
-    <message>
-        <source>Wysyłam posta... %p%</source>
-        <translation type="vanished">Sending post... %p%</translation>
     </message>
 </context>
 <context>
@@ -1747,11 +1628,7 @@ You can add and remove files from this directory, changes will become visible af
     <message>
         <location filename="src/settings/settingsdialog.cpp" line="253"/>
         <source>Zdjęcia (*.png *.gif *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zdjęcia (*.png *.gif *.jpg *.jpeg)</source>
-        <translation type="vanished">Photos (*.png *.gif *.jpg *.jpeg)</translation>
+        <translation type="unfinished">Photos (*.png *.gif *.jpg *.jpeg)</translation>
     </message>
 </context>
 <context>
@@ -1770,11 +1647,7 @@ You can add and remove files from this directory, changes will become visible af
     <message>
         <location filename="src/downloaders/tilesdownloader.cpp" line="37"/>
         <source>Podany adres nie kończy się na .png</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Podany adres nie kończy się na .png</source>
-        <translation type="vanished">Url does not end with .png</translation>
+        <translation type="unfinished">Url does not end with .png</translation>
     </message>
     <message>
         <location filename="src/downloaders/tilesdownloader.cpp" line="146"/>
@@ -1797,8 +1670,9 @@ You can add and remove files from this directory, changes will become visible af
         <translation type="vanished">Imageshack login and password</translation>
     </message>
     <message>
+        <location filename="src/uploaders/uploaderfactory.cpp" line="51"/>
         <source>Własne konto FTP</source>
-        <translation type="vanished">Own FTP account</translation>
+        <translation>Own FTP account</translation>
     </message>
     <message>
         <location filename="src/uploaders/uploaderfactory.cpp" line="47"/>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -143,7 +143,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <source>Nie udało się ustalić czasu UTC poprzez protokÃ³ł NTP.</source>
+        <source>Nie udało się ustalić czasu UTC poprzez protokół NTP.</source>
         <translation type="vanished">Quering UTC time with NTP protocol failed.</translation>
     </message>
     <message>
@@ -195,7 +195,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Zdjęcie %1 zostało obrÃ³cone zgodnie z jego orientacją zapisaną w nagłÃ³wku exif.&lt;br&gt;Czy chcesz obrÃ³cić rÃ³wnież oryginalne zdjęcie na dysku?</source>
+        <source>Zdjęcie %1 zostało obrócone zgodnie z jego orientacją zapisaną w nagłówku exif.&lt;br&gt;Czy chcesz obrócić również oryginalne zdjęcie na dysku?</source>
         <translation type="vanished">Photo %1 was rotated according to its orientation setting in exif.&lt;br&gt;Do you want to rotate the original file as well?</translation>
     </message>
     <message>
@@ -209,7 +209,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Removing position</translation>
     </message>
     <message>
-        <source>Czy usunąć pozycję rÃ³wnież z pliku na dysku?</source>
+        <source>Czy usunąć pozycję również z pliku na dysku?</source>
         <translation type="vanished">Do you want to remove position from the original file as well?</translation>
     </message>
     <message>
@@ -218,7 +218,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Rotate image</translation>
     </message>
     <message>
-        <source>Czy obrÃ³cić rÃ³wnież oryginalne zdjęcie na dysku?</source>
+        <source>Czy obrócić również oryginalne zdjęcie na dysku?</source>
         <translation type="vanished">Do you want to rotate the original file as well?</translation>
     </message>
     <message>
@@ -279,7 +279,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="vanished">Credits reset</translation>
     </message>
     <message>
-        <source>Pozostała liczba kredytÃ³w: %1 nie wystarczy na upload %2 zdjęć. Zredukuj liczbę zdjęć do %3 i sprÃ³buj jeszcze raz.</source>
+        <source>Pozostała liczba kredytów: %1 nie wystarczy na upload %2 zdjęć. Zredukuj liczbę zdjęć do %3 i spróbuj jeszcze raz.</source>
         <translation type="vanished">Remaining credits number: %1 is not enough for uploading %2 images. Decrease image number to %3 and try again.</translation>
     </message>
 </context>
@@ -647,7 +647,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>Delete arrow</translation>
     </message>
     <message>
-        <source>OtwÃ³rz fotorelację</source>
+        <source>Otwórz fotorelację</source>
         <translation type="vanished">Open photo report</translation>
     </message>
     <message>
@@ -677,7 +677,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>Once more</translation>
     </message>
     <message>
-        <source>Czy sprÃ³bować dokończyć wysyłanie fotorelacji?</source>
+        <source>Czy spróbować dokończyć wysyłanie fotorelacji?</source>
         <translation type="vanished">Try finishing photo report upload?</translation>
     </message>
     <message>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -143,7 +143,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <source>Nie udaÅo się ustalić czasu UTC poprzez protokÃ³Å NTP.</source>
+        <source>Nie udało się ustalić czasu UTC poprzez protokÃ³ł NTP.</source>
         <translation type="vanished">Quering UTC time with NTP protocol failed.</translation>
     </message>
     <message>
@@ -195,7 +195,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Zdjęcie %1 zostaÅo obrÃ³cone zgodnie z jego orientacją zapisaną w nagÅÃ³wku exif.&lt;br&gt;Czy chcesz obrÃ³cić rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
+        <source>Zdjęcie %1 zostało obrÃ³cone zgodnie z jego orientacją zapisaną w nagłÃ³wku exif.&lt;br&gt;Czy chcesz obrÃ³cić rÃ³wnieÅ¼ oryginalne zdjęcie na dysku?</source>
         <translation type="vanished">Photo %1 was rotated according to its orientation setting in exif.&lt;br&gt;Do you want to rotate the original file as well?</translation>
     </message>
     <message>
@@ -279,7 +279,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="vanished">Credits reset</translation>
     </message>
     <message>
-        <source>PozostaÅa liczba kredytÃ³w: %1 nie wystarczy na upload %2 zdjęć. Zredukuj liczbę zdjęć do %3 i sprÃ³buj jeszcze raz.</source>
+        <source>Pozostała liczba kredytÃ³w: %1 nie wystarczy na upload %2 zdjęć. Zredukuj liczbę zdjęć do %3 i sprÃ³buj jeszcze raz.</source>
         <translation type="vanished">Remaining credits number: %1 is not enough for uploading %2 images. Decrease image number to %3 and try again.</translation>
     </message>
 </context>
@@ -330,7 +330,7 @@ Wrong url will make all links corrupted.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; uzyskaÅa dostęp do Twoich danych na Imgur.</source>
+        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; uzyskała dostęp do Twoich danych na Imgur.</source>
         <translation type="vanished">Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; gained access to your data on Imgur.</translation>
     </message>
     <message>
@@ -339,7 +339,7 @@ Wrong url will make all links corrupted.</translation>
         <translation>Authorization denied</translation>
     </message>
     <message>
-        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; nie uzyskaÅa dostępu do Twoich danych na Imgur.</source>
+        <source>Aplikacja &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; nie uzyskała dostępu do Twoich danych na Imgur.</source>
         <translation type="vanished">Application  &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; didn&apos;t gain access to your data on Imgur.</translation>
     </message>
     <message>
@@ -352,11 +352,11 @@ Wrong url will make all links corrupted.</translation>
         <translation type="vanished">Application &lt;span class=&quot;accent green&quot;&gt;fotorelacjonusz&lt;/span&gt; has access to your data on Imgur.</translation>
     </message>
     <message>
-        <source>BÅąd</source>
+        <source>Błąd</source>
         <translation type="vanished">Error</translation>
     </message>
     <message>
-        <source>Podczas kontaktowania się z Imgur wystąpiÅ bÅąd.</source>
+        <source>Podczas kontaktowania się z Imgur wystąpił błąd.</source>
         <translation type="vanished">Error while connecting with Imgur. </translation>
     </message>
 </context>
@@ -651,7 +651,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">Open photo report</translation>
     </message>
     <message>
-        <source>BÅąd</source>
+        <source>Błąd</source>
         <translation type="vanished">Error</translation>
     </message>
     <message>
@@ -677,7 +677,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>Once more</translation>
     </message>
     <message>
-        <source>Czy sprÃ³bować dokoÅczyć wysyÅanie fotorelacji?</source>
+        <source>Czy sprÃ³bować dokoÅczyć wysyłanie fotorelacji?</source>
         <translation type="vanished">Try finishing photo report upload?</translation>
     </message>
     <message>
@@ -761,11 +761,11 @@ If you don&apos;t want your password stored leave this field empty, application 
 <context>
     <name>MessageHandler</name>
     <message>
-        <source>BÅąd %1 w %2&lt;br/&gt;Wiersz %3, kolumna %4:%5</source>
+        <source>Błąd %1 w %2&lt;br/&gt;Wiersz %3, kolumna %4:%5</source>
         <translation type="obsolete">Error %1 in %2&lt;br/&gt;Row %3, column %4:%5</translation>
     </message>
     <message>
-        <source>BÅąd</source>
+        <source>Błąd</source>
         <translation type="obsolete">Error</translation>
     </message>
 </context>
@@ -830,7 +830,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="obsolete">No %1 file</translation>
     </message>
     <message>
-        <source>Niepoprawna skÅadnia kml</source>
+        <source>Niepoprawna składnia kml</source>
         <translation type="vanished">Kml syntax error</translation>
     </message>
     <message>
@@ -842,11 +842,11 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="obsolete">No %1 file in kmz archive</translation>
     </message>
     <message>
-        <source>Nieudane Åadowanie pliku z mapą</source>
+        <source>Nieudane ładowanie pliku z mapą</source>
         <translation type="obsolete">Map file loading failed</translation>
     </message>
     <message>
-        <source>To nie jest plik podkÅadu mapowego.</source>
+        <source>To nie jest plik podkładu mapowego.</source>
         <translation type="vanished">This is not an overlay file.</translation>
     </message>
     <message>
@@ -878,11 +878,11 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">outFileMap.open(): %1</translation>
     </message>
     <message>
-        <source>outFileMap.write(): BÅąd zapisu danych do archiwum</source>
+        <source>outFileMap.write(): Błąd zapisu danych do archiwum</source>
         <translation type="vanished">outFileMap.write(): Error while writing data to archive</translation>
     </message>
     <message>
-        <source>map.save(): BÅąd zapisu pixmapy do archiwum</source>
+        <source>map.save(): Błąd zapisu pixmapy do archiwum</source>
         <translation type="obsolete">map.save(): Error while saving pixmap in archive</translation>
     </message>
     <message>
@@ -905,7 +905,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="vanished">No &apos;%1&apos; file in kmz archive</translation>
     </message>
     <message>
-        <source>Nieudane Åadowanie pliku z mapą, pamięć wyczerpana?</source>
+        <source>Nieudane ładowanie pliku z mapą, pamięć wyczerpana?</source>
         <translation type="vanished">Map file loading failed, memory exhausted?</translation>
     </message>
     <message>
@@ -917,7 +917,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation type="obsolete">No %1 file in kmz archive</translation>
     </message>
     <message>
-        <source>Nieudane Åadowanie pliku z mapą</source>
+        <source>Nieudane ładowanie pliku z mapą</source>
         <translation type="obsolete">Map file loading failed</translation>
     </message>
 </context>
@@ -959,7 +959,7 @@ Treść błędu:
         <source>%1:%2
 %3
 
-TreÅć bÅędu:
+TreÅć błędu:
 %4</source>
         <translation type="vanished">%1:%2
 %3
@@ -971,7 +971,7 @@ Error message:
         <source>%1:%2
 %3
 
-Miejsce bÅędu:
+Miejsce błędu:
 %4</source>
         <translation type="obsolete">%1:%2
 %3
@@ -982,7 +982,7 @@ Error at:
     <message>
         <source>%1
 
-Miejsce bÅędu:
+Miejsce błędu:
 %2</source>
         <translation type="obsolete">%1
 
@@ -1112,24 +1112,24 @@ Error at:
         <translation type="vanished">Navigating to thread...</translation>
     </message>
     <message>
-        <source>BÅąd</source>
+        <source>Błąd</source>
         <translation type="vanished">Error</translation>
     </message>
     <message>
-        <source>Nie moÅ¼na byÅo rozpocząć wysyÅania z powodu:
+        <source>Nie moÅ¼na było rozpocząć wysyłania z powodu:
 %1</source>
         <translation type="vanished">Can&apos;t start upload, because: %1</translation>
     </message>
     <message>
-        <source>Zdjęcie %1 juÅ¼ wysÅane</source>
+        <source>Zdjęcie %1 juÅ¼ wysłane</source>
         <translation type="vanished">Photo %1 already uploaded</translation>
     </message>
     <message>
-        <source>WysyÅam %1: %p%</source>
+        <source>Wysyłam %1: %p%</source>
         <translation type="vanished">Sending %1: %p%</translation>
     </message>
     <message>
-        <source>Nie moÅ¼na byÅo wysÅać obrazka %1 z powodu:
+        <source>Nie moÅ¼na było wysłać obrazka %1 z powodu:
 %2</source>
         <translation type="vanished">Photo %1 upload failed: %2</translation>
     </message>
@@ -1237,7 +1237,7 @@ Error at:
         <translation type="vanished">Like this app</translation>
     </message>
     <message>
-        <source>Wygląda na to, Å¼e juÅ¼ polubiÅeÅ program.</source>
+        <source>Wygląda na to, Å¼e juÅ¼ polubiłeÅ program.</source>
         <translation type="vanished">It seems you have already liked this app.</translation>
     </message>
     <message>
@@ -1245,7 +1245,7 @@ Error at:
         <translation type="vanished">Navigating to form... %p%</translation>
     </message>
     <message>
-        <source>WysyÅam posta... %p%</source>
+        <source>Wysyłam posta... %p%</source>
         <translation type="vanished">Sending post... %p%</translation>
     </message>
 </context>
@@ -1793,11 +1793,11 @@ You can add and remove files from this directory, changes will become visible af
         <translation type="vanished">Imageshack registration code</translation>
     </message>
     <message>
-        <source>Imageshack login i hasÅo</source>
+        <source>Imageshack login i hasło</source>
         <translation type="vanished">Imageshack login and password</translation>
     </message>
     <message>
-        <source>WÅasne konto FTP</source>
+        <source>Własne konto FTP</source>
         <translation type="vanished">Own FTP account</translation>
     </message>
     <message>

--- a/fotorelacjonusz_en_US.ts
+++ b/fotorelacjonusz_en_US.ts
@@ -677,7 +677,7 @@ If you don&apos;t want your password stored leave this field empty, application 
         <translation>Once more</translation>
     </message>
     <message>
-        <source>Czy sprÃ³bować dokoÅczyć wysyłanie fotorelacji?</source>
+        <source>Czy sprÃ³bować dokończyć wysyłanie fotorelacji?</source>
         <translation type="vanished">Try finishing photo report upload?</translation>
     </message>
     <message>
@@ -1773,7 +1773,7 @@ You can add and remove files from this directory, changes will become visible af
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Podany adres nie koÅczy się na .png</source>
+        <source>Podany adres nie kończy się na .png</source>
         <translation type="vanished">Url does not end with .png</translation>
     </message>
     <message>

--- a/src/downloaders/googlemapsdownloader.cpp
+++ b/src/downloaders/googlemapsdownloader.cpp
@@ -39,13 +39,13 @@ void GoogleMapsDownloader::finished(QNetworkReply *reply)
 {
 	if (reply->error() != QNetworkReply::NoError)
 	{
-		qDebug() << QObject::tr("Błąd pobierania mapy: %1 %2").arg(reply->error()).arg(reply->errorString());
+		qDebug() << tr("Błąd pobierania mapy: %1 %2").arg(reply->error()).arg(reply->errorString());
 		return;
 	}
 	QImage image;
 	if (!image.loadFromData(reply->readAll()))
 	{
-		qDebug() << QObject::tr("Błąd otwierania mapy.");
+		qDebug() << tr("Błąd otwierania mapy.");
 		return;
 	}
 

--- a/src/downloaders/googlemapsdownloader.h
+++ b/src/downloaders/googlemapsdownloader.h
@@ -4,11 +4,14 @@
 #include <QObject>
 #include <QPixmap>
 #include <QUrl>
+#include <QCoreApplication>
 
 #include "abstractmapdownloader.h"
 
 class GoogleMapsDownloader : public AbstractMapDownloader
 {
+	Q_DECLARE_TR_FUNCTIONS(GoogleMapsDownloader)
+
 public:
 	bool makeMap(GeoMap *map);
 	void finished(QNetworkReply *reply);

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -13,7 +13,7 @@ Exception::Exception(const char *file, int line, const char *func, QString what)
 
 void Exception::showMessage(QWidget *parent) const
 {
-	QMessageBox::critical(parent, QObject::tr("Błąd"), QObject::tr("%1:%2\n%3\n\nTreść błędu:\n%4").arg(file).arg(line).arg(func).arg(what));
+	QMessageBox::critical(parent, tr("Błąd"), tr("%1:%2\n%3\n\nTreść błędu:\n%4").arg(file).arg(line).arg(func).arg(what));
 }
 
 QString Exception::message() const

--- a/src/exception.h
+++ b/src/exception.h
@@ -2,11 +2,14 @@
 #define EXCEPTION_H
 
 #include <QString>
+#include <QCoreApplication>
 
 class QWidget;
 
 class Exception
 {
+	Q_DECLARE_TR_FUNCTIONS(Exception)
+
 public:
 	Exception(const char *file, int line, const char *func, QString what);
 	void showMessage(QWidget *parent) const;

--- a/src/exception.h
+++ b/src/exception.h
@@ -25,7 +25,6 @@ static inline bool throw_func(const char *file, int line, const char *func, QStr
 
 #define THROW(x)  throw Exception(__FILE__, __LINE__, __PRETTY_FUNCTION__, x);
 #define OR_THROW(x)	or throw_func(__FILE__, __LINE__, __PRETTY_FUNCTION__, x);
-#define TR(x) QObject::tr(x)
 
 #define SEEK_ERROR(x) (QString("Wrong offset: %1").arg(x))
 

--- a/src/settings/overlay.cpp
+++ b/src/settings/overlay.cpp
@@ -32,7 +32,7 @@ Overlay::Overlay(QString absoluteFilePath) throw (Exception)
 		file.seek(file.size() - sizeof(thumbnailSize));
 		QDataStream(&file) >> thumbnailSize; // BigEndian by default
 		if (file.size() < thumbnailSize)
-			THROW(TR("To nie jest plik podkładu mapowego."));
+			THROW(tr("To nie jest plik podkładu mapowego."));
 		file.seek(thumbnailSize);
 	}
 
@@ -41,30 +41,30 @@ Overlay::Overlay(QString absoluteFilePath) throw (Exception)
 //		QuaZip kmz(absoluteFilePath);
 		QuaZip kmz(&file);
 
-		(Suppress(), kmz.open(QuaZip::mdUnzip)) OR_THROW(TR("kmz.open(): %1").arg(kmz.getZipError()));
+		(Suppress(), kmz.open(QuaZip::mdUnzip)) OR_THROW(tr("kmz.open(): %1").arg(kmz.getZipError()));
 
 		QuaZipFile file(&kmz);
 		for (bool f = kmz.goToFirstFile(); f; f = kmz.goToNextFile())
 		{
-			file.open(QIODevice::ReadOnly) OR_THROW(TR("file.open(): %1").arg(file.getZipError()));
+			file.open(QIODevice::ReadOnly) OR_THROW(tr("file.open(): %1").arg(file.getZipError()));
 			files[file.getActualFileName()] = file.readAll();
 			file.close();
-			file.getZipError() == UNZ_OK OR_THROW(TR("file.close(): %1").arg(file.getZipError()));
+			file.getZipError() == UNZ_OK OR_THROW(tr("file.close(): %1").arg(file.getZipError()));
 		}
 
 		kmz.close();
-		kmz.getZipError() == UNZ_OK OR_THROW(TR("kmz.close(): %1").arg(kmz.getZipError()));
+		kmz.getZipError() == UNZ_OK OR_THROW(tr("kmz.close(): %1").arg(kmz.getZipError()));
 	}
 
 //	qDebug() << files.keys();
-	files.contains(DOC_KML) OR_THROW(TR("Brak pliku '%1'").arg(DOC_KML));
+	files.contains(DOC_KML) OR_THROW(tr("Brak pliku '%1'").arg(DOC_KML));
 	bool isKmz = absoluteFilePath.endsWith(".kmz");
 
 	QDomDocument doc;
-	doc.setContent(files[DOC_KML]) OR_THROW(TR("Niepoprawna składnia kml"));
+	doc.setContent(files[DOC_KML]) OR_THROW(tr("Niepoprawna składnia kml"));
 	QDomElement kml = doc.documentElement();
 	QDomElement firstChild = kml.firstChild().toElement();
-	(!kml.isNull() && !firstChild.isNull()) OR_THROW(TR("Brak tagu kml i/lub podrzędnego w pliku kml"));
+	(!kml.isNull() && !firstChild.isNull()) OR_THROW(tr("Brak tagu kml i/lub podrzędnego w pliku kml"));
 
 	name = firstChild.firstChildElement("name").text();
 	description = firstChild.firstChildElement("description").text();
@@ -79,7 +79,7 @@ Overlay::Overlay(QString absoluteFilePath) throw (Exception)
 //		writeThumbnail(0);
 	}
 	else
-		THROW(TR("Brak tagu Folder lub GroundOverlay"));
+		THROW(tr("Brak tagu Folder lub GroundOverlay"));
 
 	if (isKmz)
 	{
@@ -91,25 +91,25 @@ Overlay::Overlay(QString absoluteFilePath) throw (Exception)
 
 		{
 			QuaZip kmr(&jpg);
-			(Suppress(), kmr.open(QuaZip::mdCreate)) OR_THROW(TR("kmr.open(): %1").arg(kmr.getZipError()));
+			(Suppress(), kmr.open(QuaZip::mdCreate)) OR_THROW(tr("kmr.open(): %1").arg(kmr.getZipError()));
 
 			QuaZipFile outFileKml(&kmr);
-			outFileKml.open(QIODevice::WriteOnly, QuaZipNewInfo(DOC_KML, absoluteFilePath)) OR_THROW(TR("outFileKml.open(): %1").arg(outFileKml.getZipError()));
+			outFileKml.open(QIODevice::WriteOnly, QuaZipNewInfo(DOC_KML, absoluteFilePath)) OR_THROW(tr("outFileKml.open(): %1").arg(outFileKml.getZipError()));
 			outFileKml.write(doc.toByteArray());
 			outFileKml.close();
-			outFileKml.getZipError() == UNZ_OK OR_THROW(TR("outFileKml.close(): %1").arg(outFileKml.getZipError()));
+			outFileKml.getZipError() == UNZ_OK OR_THROW(tr("outFileKml.close(): %1").arg(outFileKml.getZipError()));
 
 			foreach (OverlayImage *image, images)
 			{
 				QuaZipFile outFileMap(&kmr);
-				outFileMap.open(QIODevice::WriteOnly, QuaZipNewInfo(image->href(), absoluteFilePath)) OR_THROW(TR("outFileMap.open(): %1").arg(outFileMap.getZipError()));
-				outFileMap.write(image->data()) == image->data().size() OR_THROW(TR("outFileMap.write(): Błąd zapisu danych do archiwum"));
+				outFileMap.open(QIODevice::WriteOnly, QuaZipNewInfo(image->href(), absoluteFilePath)) OR_THROW(tr("outFileMap.open(): %1").arg(outFileMap.getZipError()));
+				outFileMap.write(image->data()) == image->data().size() OR_THROW(tr("outFileMap.write(): Błąd zapisu danych do archiwum"));
 				outFileMap.close();
-				outFileMap.getZipError() == UNZ_OK OR_THROW(TR("outFileMap.close(): %1").arg(outFileMap.getZipError()));
+				outFileMap.getZipError() == UNZ_OK OR_THROW(tr("outFileMap.close(): %1").arg(outFileMap.getZipError()));
 			}
 
 			kmr.close();
-			kmr.getZipError() == UNZ_OK OR_THROW(TR("kmr.close(): %1").arg(kmr.getZipError()));
+			kmr.getZipError() == UNZ_OK OR_THROW(tr("kmr.close(): %1").arg(kmr.getZipError()));
 		}
 		jpg.open(QIODevice::Append);
 		jpg.seek(jpg.size());

--- a/src/settings/overlay.h
+++ b/src/settings/overlay.h
@@ -4,9 +4,12 @@
 #include "overlayimage.h"
 #include "exception.h"
 #include <QString>
+#include <QCoreApplication>
 
 class Overlay : public AbstractMapDownloader
 {
+	Q_DECLARE_TR_FUNCTIONS(Overlay)
+
 public:
 	Overlay(QString absoluteFilePath) throw (Exception);
 	~Overlay();

--- a/src/settings/overlayimage.cpp
+++ b/src/settings/overlayimage.cpp
@@ -22,7 +22,7 @@ OverlayImage::OverlayImage(QDomElement groundOverlay, const QMap<QString, QByteA
 	QDomElement latLonBox = groundOverlay.firstChildElement("LatLonBox");
 	m_name = groundOverlay.firstChildElement("name").text();
 
-	(!icon.isNull() && !latLonBox.isNull()) OR_THROW(TR("Brak tagu w pliku kml"));
+	(!icon.isNull() && !latLonBox.isNull()) OR_THROW(tr("Brak tagu w pliku kml"));
 	m_href = icon.firstChildElement("href").text();
 
 	const qreal left = latLonBox.firstChildElement("west").text().toDouble();
@@ -40,13 +40,13 @@ OverlayImage::OverlayImage(QDomElement groundOverlay, const QMap<QString, QByteA
 	poly << poly.first(); // close
 	box = poly.boundingRect();
 
-	files.contains(m_href) OR_THROW(TR("Brak pliku '%1' w archiwum kmz").arg(m_href));
+	files.contains(m_href) OR_THROW(tr("Brak pliku '%1' w archiwum kmz").arg(m_href));
 	imageData = files.value(m_href);
 
 	if (isKmz) // rotate imageData
 	{
 		QImage image;
-		image.loadFromData(imageData) OR_THROW(TR("Nieudane ładowanie pliku z mapą, pamięć wyczerpana?"));
+		image.loadFromData(imageData) OR_THROW(tr("Nieudane ładowanie pliku z mapą, pamięć wyczerpana?"));
 
 		QTransform transform;
 		transform.rotate(-rotation);
@@ -54,7 +54,7 @@ OverlayImage::OverlayImage(QDomElement groundOverlay, const QMap<QString, QByteA
 
 		QBuffer buffer(&imageData);
 		buffer.open(QIODevice::WriteOnly | QIODevice::Truncate);
-		image.save(&buffer, "jpg") OR_THROW(TR("Nieudane zapisanie mapy do bufora, pamięć wyczerpana?"));
+		image.save(&buffer, "jpg") OR_THROW(tr("Nieudane zapisanie mapy do bufora, pamięć wyczerpana?"));
 	}
 
 	QBuffer buffer(&imageData);

--- a/src/settings/overlayimage.h
+++ b/src/settings/overlayimage.h
@@ -8,6 +8,7 @@
 #include <QPolygonF>
 #include <QImage>
 #include <QDomElement>
+#include <QCoreApplication>
 
 /*
  * This class has three coordinate systems:
@@ -18,6 +19,8 @@
  */
 class OverlayImage : public AbstractMapDownloader
 {
+	Q_DECLARE_TR_FUNCTIONS(OverlayImage)
+
 public:
 	// the overlay
 	OverlayImage(QDomElement groundOverlay, const QMap<QString, QByteArray> &files, bool isKmz) throw (Exception);

--- a/src/widgets/abstractimage.cpp
+++ b/src/widgets/abstractimage.cpp
@@ -8,7 +8,7 @@ AbstractImage::~AbstractImage()
 
 QString AbstractImage::fileName() const
 {
-	return QObject::tr("mapa.jpg");
+	return tr("mapa.jpg");
 }
 
 QString AbstractImage::caption() const

--- a/src/widgets/abstractimage.h
+++ b/src/widgets/abstractimage.h
@@ -2,11 +2,14 @@
 #define ABSTRACTIMAGE_H
 
 #include <QString>
+#include <QCoreApplication>
 
 class QIODevice;
 
 class AbstractImage
 {
+	Q_DECLARE_TR_FUNCTIONS(AbstractImage)
+
 public:
 	enum State { Ready, Uploaded, Assigned };
 	typedef QString &(QString::*AddFunc)(const QString &);


### PR DESCRIPTION
- Fix encoding of characters specific for Polish alphabet.
- Leverage `Q_DECLARE_TR_FUNCTIONS` to enable `tr` method in non-Qt classes.
- Fix trivial issues in translations.
- Update several translations.
- Delete some outdated translations.
- Mark translations as finished.