### PR TITLE
Improve menu look&feel on MacOS

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -8,6 +8,9 @@
 Application::Application(int &argc, char **argv):
 	QApplication(argc, argv)
 {
+	#if defined(Q_OS_MACOS)
+	this->setAttribute(Qt::AA_DontShowIconsInMenus, true);
+	#endif
 }
 
 QString Application::applicationSettingsName()

--- a/src/widgets/mainwindow.ui
+++ b/src/widgets/mainwindow.ui
@@ -348,6 +348,9 @@
    <property name="text">
     <string>&amp;Ustawienia</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::PreferencesRole</enum>
+   </property>
   </action>
   <action name="action_close">
    <property name="icon">
@@ -360,6 +363,9 @@
    <property name="toolTip">
     <string>Zamknij</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::QuitRole</enum>
+   </property>
   </action>
   <action name="action_about">
    <property name="icon">
@@ -368,6 +374,9 @@
    </property>
    <property name="text">
     <string>&amp;O programie</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::AboutRole</enum>
    </property>
   </action>
   <action name="action_Qt_information">
@@ -380,6 +389,9 @@
    </property>
    <property name="toolTip">
     <string>Informacje o Qt</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::AboutQtRole</enum>
    </property>
   </action>
   <action name="action_open_photorelation">


### PR DESCRIPTION
When compiling for MacOS, hide icons and move some items to conventional locations.