### PR TITLE
Replace dynamic exception specifications

### DIFF
--- a/src/myexif/exififd.cpp
+++ b/src/myexif/exififd.cpp
@@ -12,7 +12,7 @@ ExifIfd::ExifIfd():
 {
 }
 
-ExifIfd::ExifIfd(QDataStream &stream) throw (Exception):
+ExifIfd::ExifIfd(QDataStream &stream) noexcept(false):
 	nextIFD(0),
 	nextIFDSought(false)
 {

--- a/src/myexif/exififd.h
+++ b/src/myexif/exififd.h
@@ -21,7 +21,7 @@ public:
 	};
 
 	ExifIfd();
-	ExifIfd(QDataStream &stream) throw (Exception);
+	ExifIfd(QDataStream &stream) noexcept(false);
 	void write(QDataStream &stream, QByteArray &data, bool hasNext) const;
 
 	bool hasNext() const;

--- a/src/myexif/exifimageheader.cpp
+++ b/src/myexif/exifimageheader.cpp
@@ -275,7 +275,7 @@ ExifIfd &ExifImageHeader::gpsIFD()
 	return ifds[0].embededIfd(ExifIfd::GpsInfoIfdPointer);
 }
 
-void ExifImageHeader::loadFromJpeg(QDataStream &fileStream) throw (Exception)
+void ExifImageHeader::loadFromJpeg(QDataStream &fileStream) noexcept(false)
 {
 	fileStream.setByteOrder(QDataStream::BigEndian);
 	ExifMarker(fileStream).isSOI() OR_THROW("First marker is not SOI");
@@ -313,7 +313,7 @@ void ExifImageHeader::loadFromJpeg(QDataStream &fileStream) throw (Exception)
 	!fileStream.atEnd() OR_THROW("APP1 marker not found");
 }
 
-void ExifImageHeader::saveToJpeg(QDataStream &fileStream) const throw (Exception)
+void ExifImageHeader::saveToJpeg(QDataStream &fileStream) const noexcept(false)
 {
 	fileStream.setByteOrder(QDataStream::BigEndian);
 	ExifMarker(fileStream).isSOI() OR_THROW("First marker is not SOI");
@@ -331,7 +331,7 @@ void ExifImageHeader::saveToJpeg(QDataStream &fileStream) const throw (Exception
 		saveToJpeg(ExifMarker(m1, ExifMarker::APP1));
 }
 
-void ExifImageHeader::saveToJpeg(ExifMarker app1) const throw (Exception)
+void ExifImageHeader::saveToJpeg(ExifMarker app1) const noexcept(false)
 {
 	QByteArray data;
 	QDataStream stream(&data, QIODevice::WriteOnly);

--- a/src/myexif/exifimageheader.h
+++ b/src/myexif/exifimageheader.h
@@ -202,9 +202,9 @@ private:
 	ExifIfd &exifIFD();
 	ExifIfd &gpsIFD();
 
-	void loadFromJpeg(QDataStream &fileStream) throw (Exception);
-	void saveToJpeg(QDataStream &fileStream) const throw (Exception);
-	void saveToJpeg(ExifMarker app1) const throw (Exception);
+	void loadFromJpeg(QDataStream &fileStream) noexcept(false);
+	void saveToJpeg(QDataStream &fileStream) const noexcept(false);
+	void saveToJpeg(ExifMarker app1) const noexcept(false);
 
 	typedef QMap<int, ExifIfd> ExifIfdMap;
 	ExifIfdMap ifds;

--- a/src/myexif/exifmarker.cpp
+++ b/src/myexif/exifmarker.cpp
@@ -3,7 +3,7 @@
 #include <QFile>
 #include <QDebug>
 
-ExifMarker::ExifMarker(QDataStream &stream) throw (Exception):
+ExifMarker::ExifMarker(QDataStream &stream) noexcept(false):
 	stream(stream),
 	start(stream.device()->pos()),
 	size(0)
@@ -52,7 +52,7 @@ bool ExifMarker::isSOS() const
 	return number == SOS;
 }
 
-QByteArray ExifMarker::readData(const QByteArray &header) const throw (Exception)
+QByteArray ExifMarker::readData(const QByteArray &header) const noexcept(false)
 {
 	const int pos = stream.device()->pos();
 	stream.device()->seek(start + sizeof(ff) + sizeof(number) + sizeof(size));

--- a/src/myexif/exifmarker.h
+++ b/src/myexif/exifmarker.h
@@ -15,14 +15,14 @@ public:
 		SOS  = 0xda
 	};
 
-	ExifMarker(QDataStream &stream) throw (Exception);
+	ExifMarker(QDataStream &stream) noexcept(false);
 	ExifMarker(const ExifMarker &other, MarkerNumber number); // insert before
 	bool isAPP0() const;
 	bool isAPP1() const;
 	bool isSOI() const;
 	bool isSOS() const;
 
-	QByteArray readData(const QByteArray &header = QByteArray()) const throw (Exception);
+	QByteArray readData(const QByteArray &header = QByteArray()) const noexcept(false);
 	void writeData(const QByteArray &data, const QByteArray &header = QByteArray());
 
 private:

--- a/src/myexif/exifvalue.cpp
+++ b/src/myexif/exifvalue.cpp
@@ -240,7 +240,7 @@ QDateTime ExifValue::toDateTime() const
 #pragma GCC diagnostic ignored "-Wtype-limits"
 
 template <class T>
-QVector<T> ExifValue::readVector(QDataStream &stream) throw (Exception)
+QVector<T> ExifValue::readVector(QDataStream &stream) noexcept(false)
 {
 	quint32 count;
 	quint32 offset;

--- a/src/myexif/exifvalue.h
+++ b/src/myexif/exifvalue.h
@@ -87,7 +87,7 @@ public:
 
 private:
 	template <class T>
-	QVector<T> readVector(QDataStream &stream) throw (Exception);
+	QVector<T> readVector(QDataStream &stream) noexcept(false);
 	template <class T>
 	void readValue(QDataStream &stream, quint16 type);
 	void readString(QDataStream &stream, quint16 type);

--- a/src/settings/overlay.cpp
+++ b/src/settings/overlay.cpp
@@ -22,7 +22,7 @@
 
 #define DOC_KML "doc.kml"
 
-Overlay::Overlay(QString absoluteFilePath) throw (Exception)
+Overlay::Overlay(QString absoluteFilePath) noexcept(false)
 {
 	quint32 thumbnailSize;
 	QFile file(absoluteFilePath);

--- a/src/settings/overlay.h
+++ b/src/settings/overlay.h
@@ -11,7 +11,7 @@ class Overlay : public AbstractMapDownloader
 	Q_DECLARE_TR_FUNCTIONS(Overlay)
 
 public:
-	Overlay(QString absoluteFilePath) throw (Exception);
+	Overlay(QString absoluteFilePath) noexcept(false);
 	~Overlay();
 
 	QString toString() const;

--- a/src/settings/overlayimage.cpp
+++ b/src/settings/overlayimage.cpp
@@ -16,7 +16,7 @@ int sgn(T v)
 	return (T(0) < v) - (v < T(0));
 }
 
-OverlayImage::OverlayImage(QDomElement groundOverlay, const QMap<QString, QByteArray> &files, bool isKmz) throw (Exception)
+OverlayImage::OverlayImage(QDomElement groundOverlay, const QMap<QString, QByteArray> &files, bool isKmz) noexcept(false)
 {
 	QDomElement icon = groundOverlay.firstChildElement("Icon");
 	QDomElement latLonBox = groundOverlay.firstChildElement("LatLonBox");

--- a/src/settings/overlayimage.h
+++ b/src/settings/overlayimage.h
@@ -23,7 +23,7 @@ class OverlayImage : public AbstractMapDownloader
 
 public:
 	// the overlay
-	OverlayImage(QDomElement groundOverlay, const QMap<QString, QByteArray> &files, bool isKmz) throw (Exception);
+	OverlayImage(QDomElement groundOverlay, const QMap<QString, QByteArray> &files, bool isKmz) noexcept(false);
 	// dummy overlay for calculations only
 	OverlayImage(QRectF latLongBox, QSize maxSize);
 	bool makeMap(GeoMap *map);

--- a/src/widgets/imagewidget.cpp
+++ b/src/widgets/imagewidget.cpp
@@ -25,7 +25,7 @@
 #include <QCheckBox>
 #include <QTime>
 
-ImageWidget::ImageWidget(QWidget *parent, QString _filePath, QDataStream *stream) throw(Exception):
+ImageWidget::ImageWidget(QWidget *parent, QString _filePath, QDataStream *stream) noexcept(false):
 	SelectableWidget<ImageWidget>(parent),
 	filePath(_filePath),
 	m_brightness(BRIGHTNESS_DEFAULT), m_contrast(CONTRAST_DEFAULT), m_gamma(GAMMA_DEFAULT),

--- a/src/widgets/imagewidget.h
+++ b/src/widgets/imagewidget.h
@@ -24,7 +24,7 @@ class ImageWidget : public SelectableWidget<ImageWidget>, public AbstractImage
 	Q_OBJECT
 
 public:
-	explicit ImageWidget(QWidget *parent, QString _filePath, QDataStream *stream = nullptr) throw (Exception);
+	explicit ImageWidget(QWidget *parent, QString _filePath, QDataStream *stream = nullptr) noexcept(false);
 	~ImageWidget();
 
 	virtual QString fileName() const;

--- a/src/widgets/mainwindow.cpp
+++ b/src/widgets/mainwindow.cpp
@@ -404,7 +404,7 @@ void MainWindow::processEvents() const
 	ui->scrollArea->ensureVisible(0, 1000000);
 }
 
-ImageWidget *MainWindow::newImage(QString filePath, QDataStream *stream) throw(Exception)
+ImageWidget *MainWindow::newImage(QString filePath, QDataStream *stream) noexcept(false)
 {
 	ImageWidget *widget = new ImageWidget(ui->postWidget, filePath, stream);
 	ui->postLayout->addWidget(widget);

--- a/src/widgets/mainwindow.h
+++ b/src/widgets/mainwindow.h
@@ -68,7 +68,7 @@ private slots:
 
 protected:
 	void processEvents() const;
-	ImageWidget *newImage(QString filePath, QDataStream *stream) throw(Exception);
+	ImageWidget *newImage(QString filePath, QDataStream *stream) noexcept(false);
 	ImageWidget *imageAt(int i) const;
 	QList<AbstractImage *> imageList() const;
 	void closeEvent(QCloseEvent *event);


### PR DESCRIPTION
Replace deprecated language feature with noexcept specifier.

See:

- https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#e30-dont-use-exception-specifications
- https://en.cppreference.com/w/cpp/language/noexcept_spec
- https://en.cppreference.com/w/cpp/language/except_spec