### PR TITLE
Change version to 3.0.0-alpha1

### DIFF
--- a/fotorelacjonusz.pro
+++ b/fotorelacjonusz.pro
@@ -7,7 +7,7 @@
 TEMPLATE = app
 TARGET = fotorelacjonusz
 macx:TARGET = Fotorelacjonusz
-VERSION = 2.99.0
+VERSION = 3.0.0-alpha1
 
 # Used in CFBundleIdentifier in Info.plist on Mac
 QMAKE_TARGET_BUNDLE_PREFIX = org.forumpolskichwiezowcow


### PR DESCRIPTION
It makes much more sense to indicate prereleases by adding some non-numeric part.