### PR TITLE
Get rid of Version class

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -53,12 +53,22 @@ int Application::showWindowAndExec()
 
 QString Application::applicationSettingsName()
 {
-	return applicationName() + QString::number(Version(applicationVersion()).major);
+	return applicationName() + QString::number(applicationVersionNumber().majorVersion());
 }
 
 QString Application::applicationNameAndVersion()
 {
 	return applicationName() + " " + applicationVersion();
+}
+
+/**
+ * @brief Basically applicationVersion(), but as a QVersionNumber.
+ * @return application version number
+ * @see QVersionNumber, QCoreApplication::applicationVersion()
+ */
+QVersionNumber Application::applicationVersionNumber()
+{
+	return QVersionNumber::fromString(applicationVersion());
 }
 
 void Application::busy()

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -1,4 +1,4 @@
-#define _SYS_SYSMACROS_H // conflicts with major() and minor() 
+#define _SYS_SYSMACROS_H // conflicts with major() and minor()
 
 #include "application.h"
 #include "embeddedjavascript.h"

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -96,16 +96,3 @@ bool Application::notify(QObject *object, QEvent *event)
 	}
 	return false;
 }
-
-Version::Version(QString version):
-	major (version.section('.', 0, 0).toInt()),
-	format(version.section('.', 1, 1).toInt()),
-	minor (version.section('.', 2, 2).toInt())
-{
-	Q_ASSERT(QRegExp("\\d+\\.\\d+\\.\\d+").exactMatch(version));
-}
-
-bool Version::isPhrCompatible(const Version &other)
-{
-	return major == other.major && format == other.format;
-}

--- a/src/application.h
+++ b/src/application.h
@@ -2,6 +2,7 @@
 #define APPLICATION_H
 
 #include <QApplication>
+#include <QVersionNumber>
 
 class Application : public QApplication
 {
@@ -13,6 +14,7 @@ public:
 
 	static QString applicationSettingsName();
 	static QString applicationNameAndVersion();
+	static QVersionNumber applicationVersionNumber();
 	
 	static void busy();
 	static void idle();

--- a/src/application.h
+++ b/src/application.h
@@ -21,18 +21,7 @@ public:
 	
 protected:
 	bool notify(QObject *object, QEvent *event);
-	
-};
 
-class Version
-{
-public:
-	Version(QString version = QApplication::applicationVersion());
-	bool isPhrCompatible(const Version &other);
-	
-	const int major;
-	const int format;
-	const int minor;
 };
 
 #endif // APPLICATION_H

--- a/src/application.h
+++ b/src/application.h
@@ -15,10 +15,10 @@ public:
 	static QString applicationSettingsName();
 	static QString applicationNameAndVersion();
 	static QVersionNumber applicationVersionNumber();
-	
+
 	static void busy();
 	static void idle();
-	
+
 protected:
 	bool notify(QObject *object, QEvent *event);
 


### PR DESCRIPTION
Delete our custom but barely used `Version` class. Replace it with `QVersionNumber` where needed.