### PR TITLE
Replace qMemSet with stdlib's memset

### DIFF
--- a/src/widgets/ntppacket.cpp
+++ b/src/widgets/ntppacket.cpp
@@ -23,5 +23,5 @@ void NtpTimestamp::setDateTime(QDateTime dateTime)
 
 NtpHeader::NtpHeader()
 {
-	qMemSet(reinterpret_cast<void *>(this), 0, sizeof(NtpHeader));
+	memset(reinterpret_cast<void *>(this), 0, sizeof(NtpHeader));
 }


### PR DESCRIPTION
qMemSet has been removed in Qt5.

See (neither link is authoritative):
- https://github.com/diorahman/qntp-example/issues/2
- https://gitlab.com/pteam/pteam-qtbase/commit/7be255156feb7636a5cca5c4fe78f42879ffe69b