### PR TITLE
Use older Qt serialization format in report drafts

### DIFF
--- a/src/widgets/mainwindow.cpp
+++ b/src/widgets/mainwindow.cpp
@@ -100,7 +100,7 @@ void MainWindow::loadDraftFormat3A(QString filePath)
 	QByteArray fileFormatIdentifier;
 	QByteArray photoReportFileComment;
 
-	in.setVersion(QDataStream::Qt_5_12);
+	in.setVersion(QDataStream::Qt_5_6);
 	in >> fileFormatIdentifier;
 
 	if (fileFormatIdentifier != QByteArray("FOTORELACJONUSZ.3A.")) {
@@ -141,7 +141,7 @@ void MainWindow::saveDraft(QString filePath)
 	QFile file(filePath);
 	file.open(QIODevice::WriteOnly);
 	QDataStream out(&file);
-	out.setVersion(QDataStream::Qt_5_12);
+	out.setVersion(QDataStream::Qt_5_6);
 	out << QByteArray("FOTORELACJONUSZ.3A.");
 	out << photoReportFileComment << ui->header->toPlainText() << ui->footer->toPlainText() << ui->postLayout->count() << *ui->commonMap;
 


### PR DESCRIPTION
Qt 5.12 is often unavailable in slightly older Linux distros.  Hence, in order to avoid necessity of static linking, let's switch to a slightly older serialization format.

See: https://doc.qt.io/qt-5/qdatastream.html#Version-enum.