### PR TITLE
Make Travis build script more general, and easier to customize for different operating systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,27 +5,11 @@ before_install:
   - third-party/qt_installer/qt_installer.sh
 
 install:
-  # QtFtp
-  - pushd third-party/qtftp
-  - qmake CONFIG+=staticlib CONFIG+=c++11 CONFIG+=release
-  - make
-  - popd
-
-  # QuaZIP
-  - pushd third-party/quazip
-  - qmake CONFIG+=staticlib CONFIG+=c++11 CONFIG+=release
-  - make
-  - popd
-
-  # Fotorelacjonusz
   - ci/write_secrets_h.sh
-  - ci/compile_icon_set.sh
-  - lrelease fotorelacjonusz.pro
-  - qmake CONFIG+=release LIBS+=-lz
-  - make
+  - ci/build_on_${TRAVIS_OS_NAME}.sh
 
 script:
-  - ${EXE} -v
+  - ci/run_checks.sh
 
 before_deploy:
   # Set TRAVIS_TAG to "nightly" if blank (i.e. triggered by push to master).
@@ -53,7 +37,6 @@ matrix:
     - os: osx
       osx_image: xcode10.2
       env:
-        - EXE=./Fotorelacjonusz.app/Contents/MacOS/Fotorelacjonusz
         - PACKAGE_NAME="Fotorelacjonusz-TAG-macos.tar.gz"
         - PATH="/opt/Qt/5.12.3/clang_64/bin:${PATH}"
         - QT_INSTALLER_DOWNLOAD_NAME="qt-unified-mac-x64-online.dmg"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ script:
 before_deploy:
   # Set TRAVIS_TAG to "nightly" if blank (i.e. triggered by push to master).
   - export TRAVIS_TAG=${TRAVIS_TAG:-nightly}
-  # Substitute TAG with $TRAVIS_TAG.
-  - export PACKAGE_NAME="${PACKAGE_NAME/TAG/${TRAVIS_TAG}}"
   - git tag -a -f -m "Created by Travis" $TRAVIS_TAG
   - ci/package.sh
 
 deploy:
   provider: releases
+  file_glob: true
+  file: release/*
   overwrite: true
   skip_cleanup: true
   api_key:
@@ -29,15 +29,12 @@ deploy:
     repo: skalee/fotorelacjonusz
     all_branches: true
     condition: ("x${TRAVIS_TAG}" != "x") || ("${TRAVIS_BRANCH}" = master)
-  file:
-    - "${PACKAGE_NAME}"
 
 matrix:
   include:
     - os: osx
       osx_image: xcode10.2
       env:
-        - PACKAGE_NAME="Fotorelacjonusz-TAG-macos.tar.gz"
         - PATH="/opt/Qt/5.12.3/clang_64/bin:${PATH}"
         - QT_INSTALLER_DOWNLOAD_NAME="qt-unified-mac-x64-online.dmg"
         - QT_INSTALLER_VARS="${TRAVIS_BUILD_DIR}/ci/qt_installer_vars_mac.js"

--- a/ci/build_on_osx.sh
+++ b/ci/build_on_osx.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+# QtFtp
+travis_fold start "install.qtftp"
+set -x
+pushd third-party/qtftp
+qmake CONFIG+=staticlib CONFIG+=c++11 CONFIG+=release
+make
+popd
+set +x
+travis_fold end "install.qtftp"
+
+# QuaZIP
+travis_fold start "install.quazip"
+set -x
+pushd third-party/quazip
+qmake CONFIG+=staticlib CONFIG+=c++11 CONFIG+=release
+make
+popd
+set +x
+travis_fold end "install.quazip"
+
+# Fotorelacjonusz
+travis_fold start "install.fotorelacjonusz"
+set -x
+ci/compile_icon_set.sh
+lrelease fotorelacjonusz.pro
+qmake CONFIG+=release LIBS+=-lz
+make
+set +x
+travis_fold end "install.fotorelacjonusz"

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -5,10 +5,14 @@ set -e
 travis_fold start "before_deploy.package"
 echo "Packing application"
 
+rm -rf ./release
+
 case "${TRAVIS_OS_NAME}" in
 	osx)
+		PACKAGE_NAME="Fotorelacjonusz-${TRAVIS_TAG}-macos"
+		mkdir -p release
 		macdeployqt Fotorelacjonusz.app -verbose=2
-		tar czf "${PACKAGE_NAME}" Fotorelacjonusz.app
+		tar czf "release/${PACKAGE_NAME}.tar.gz" Fotorelacjonusz.app
 		;;
 esac
 

--- a/ci/run_checks.sh
+++ b/ci/run_checks.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+echo "Running basic checks"
+
+case "${TRAVIS_OS_NAME}" in
+	osx)
+		open ./Fotorelacjonusz.app --args -v
+		;;
+esac


### PR DESCRIPTION
1. Extract build phases into system-specific Bash scripts, instead of interpolating a not-so-generic sequence of commands with environment variables 
2. Simplify distributing binaries by using wildcards.