### PR TITLE
Use Qt features to improve code compatibility

### DIFF
--- a/src/downloaders/tilesdownloader.cpp
+++ b/src/downloaders/tilesdownloader.cpp
@@ -7,7 +7,7 @@
 #include <QNetworkReply>
 #include <QMessageBox>
 #include <QApplication>
-#include <qmath.h>
+#include <QtMath>
 
 #include "settings/settingsdialog.h"
 #include "gpsdata.h"

--- a/src/exception.h
+++ b/src/exception.h
@@ -26,8 +26,8 @@ static inline bool throw_func(const char *file, int line, const char *func, QStr
 }
 
 
-#define THROW(x)  throw Exception(__FILE__, __LINE__, __PRETTY_FUNCTION__, x);
-#define OR_THROW(x)	or throw_func(__FILE__, __LINE__, __PRETTY_FUNCTION__, x);
+#define THROW(x)  throw Exception(__FILE__, __LINE__, Q_FUNC_INFO, x);
+#define OR_THROW(x)	or throw_func(__FILE__, __LINE__, Q_FUNC_INFO, x);
 
 #define SEEK_ERROR(x) (QString("Wrong offset: %1").arg(x))
 

--- a/src/myexif/exifimageheader.cpp
+++ b/src/myexif/exifimageheader.cpp
@@ -7,7 +7,7 @@
 #include <QDebug>
 #include <QBuffer>
 #include <QIODevice>
-#include <qmath.h>
+#include <QtMath>
 
 const QByteArray ExifImageHeader::exifHeader("Exif\0\0", 6);
 

--- a/src/settings/overlay.cpp
+++ b/src/settings/overlay.cpp
@@ -17,8 +17,7 @@
 #include <QtAlgorithms>
 #include <QVector2D>
 #include <QMatrix4x4>
-#include <qmath.h>
-#include <cmath>
+#include <QtMath>
 
 #define DOC_KML "doc.kml"
 

--- a/src/settings/overlayimage.cpp
+++ b/src/settings/overlayimage.cpp
@@ -6,7 +6,7 @@
 #include <QBuffer>
 #include <QImageReader>
 #include <QVector2D>
-#include <cmath>
+#include <QtMath>
 
 const qreal OverlayImage::R = 6371000;
 

--- a/src/widgets/arrowwidget.cpp
+++ b/src/widgets/arrowwidget.cpp
@@ -5,7 +5,7 @@
 #include <QPainter>
 #include <QDebug>
 #include <QMouseEvent>
-#include <cmath>
+#include <QtMath>
 
 const int ArrowWidget::margin = 7;
 

--- a/src/widgets/replydialog.cpp
+++ b/src/widgets/replydialog.cpp
@@ -13,7 +13,7 @@
 #include <QDesktopServices>
 #include <QBuffer>
 #include <QWebChannel>
-#include <QtCore/qmath.h>
+#include <QtMath>
 
 #define ALL_IMAGES_PROGRESS_MULTIPLIER 10000
 #define DONT_SHOW_FORUM_INFO "dont_show_forum_info"


### PR DESCRIPTION
– Replace `cmath` headers and similar with `QtMath`.
– Use `Q_FUNC_INFO` macro instead of GCC-specific `__PRETTY_FUNCTION__`.

These greatly help to compile with MSVC.